### PR TITLE
Set omnifunc to dap.omnifunc in watches buffer

### DIFF
--- a/lua/dapui/elements/watches.lua
+++ b/lua/dapui/elements/watches.lua
@@ -190,6 +190,7 @@ function M.on_open(buf, render_receiver)
   vim.fn.prompt_setcallback(buf, add_watch)
   vim.api.nvim_buf_set_option(buf, "filetype", "dapui_watches")
   vim.api.nvim_buf_set_option(buf, "buftype", "prompt")
+  vim.api.nvim_buf_set_option(buf, 'omnifunc', "v:lua.require'dap'.omnifunc")
   pcall(vim.api.nvim_buf_set_name, buf, M.name)
   vim.api.nvim_buf_set_keymap(
     buf,


### PR DESCRIPTION
This lets users use omni-completion to complete variable names within
the watches buffer.

This also works together with the `autocompl` extension in dap, so users
could add a `dapui_watches.vim` in `ftplugin` with:

    lua require('dap.ext.autocompl').attach()

And it would automatically trigger the omnifunction on the
signatureTrigger characters (usually `.`)


Nice work so far :)