### PR TITLE
Use `"stacks"` in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ require("dapui").setup({
     elements = {
       -- You can change the order of elements in the sidebar
       "scopes",
-      "scopes",
+      "stacks",
       "watches"
     },
     width = 40,


### PR DESCRIPTION
You probably meant to show case the default values for `elements` in the README.