### PR TITLE
fix: attempt to index local 'path' (a nil value)

### DIFF
--- a/lua/dapui/elements/stacks.lua
+++ b/lua/dapui/elements/stacks.lua
@@ -25,6 +25,9 @@ function Element:render_frames(frames, render_state, indent)
     new_line = new_line .. frame.name .. " "
 
     if frame.source ~= nil then
+      if frame.source.path == nil then
+          frame.source.path = frame.source.name
+      end
       local source_name = require("dapui.util").pretty_name(frame.source.path)
       render_state:add_match("DapUISource", line_no, #new_line + 1, #source_name)
       new_line = new_line .. source_name


### PR DESCRIPTION
Hi,

Debugging a simple rust script. I'm getting `"attempt to index local 'path' (a nil value)"` during load/steps and the "stacks" windows remains empty. Running `.stacks` in the repl works.

It's fixed by adding

```lua
      if frame.source.path == nil then
          frame.source.path = frame.source.name
      end
```

Not sure if this has side effects but it fixes my immediate problem :)  