### PR TITLE
docs: fix default config syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ require("dapui").setup({
     },
     height = 10,
     position = "bottom" -- Can be "bottom" or "top"
-  }
+  },
   floating = {
     max_height = nil, -- These can be integers or a float between 0 and 1.
     max_width = nil   -- Floats will be treated as percentage of your screen.


### PR DESCRIPTION
Fix default config docs syntax error