### PR TITLE
Changes default icons to be compatible with more fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Default settings:
 ```lua
 require("dapui").setup({
   icons = {
-    expanded = "⯆",
-    collapsed = "⯈"
+    expanded = "▼",
+    collapsed = "▶"
   },
   mappings = {
     -- Use a table to apply multiple mappings

--- a/lua/dapui.lua
+++ b/lua/dapui.lua
@@ -12,8 +12,8 @@ local elements = {
 
 local default_config = {
   icons = {
-    expanded = "▼",
-    collapsed = "▶"
+    expanded = "▾",
+    collapsed = "▸"
   },
   mappings = {
     expand = {"<CR>", "<2-LeftMouse>"},

--- a/lua/dapui.lua
+++ b/lua/dapui.lua
@@ -12,8 +12,8 @@ local elements = {
 
 local default_config = {
   icons = {
-    expanded = "⯆",
-    collapsed = "⯈"
+    expanded = "▼",
+    collapsed = "▶"
   },
   mappings = {
     expand = {"<CR>", "<2-LeftMouse>"},


### PR DESCRIPTION
I'm using the font JetBrainsMono and the default icons for `expanded` and `collapsed` do not display correctly. With this simple tweak, the default looks basically don't change, but it works better with my font (and I assume many others).