### PR TITLE
Disable default theme when color scheme defines dap-ui colors.

### DIFF
--- a/lua/dapui/config/init.lua
+++ b/lua/dapui/config/init.lua
@@ -60,6 +60,7 @@ local default_config = {
     },
   },
   windows = { indent = 1 },
+  theme = true,
 }
 
 local user_config = {}
@@ -126,7 +127,9 @@ function M.setup(config)
   ------------------------
 
   user_config = filled
-  require("dapui.config.highlights").setup()
+  if filled.theme then
+    require("dapui.config.highlights").setup()
+  end
 end
 
 function M.mappings()


### PR DESCRIPTION
This PR adds an option to disable the built-in theme and load a custom one through a supported theme.  For example, [nord.nvim](https://github.com/shaunsingh/nord.nvim) supports `nvim-dap-ui`.

Example:

```lua
local options = {
  theme = false  -- disable the built-in theme since since the loaded colorscheme configures it.
}

local status_ok, dapui - pcall(require, "dapui")
if not status_ok then
  vim.notify("Plugin: nvim-dap-ui not installed")
  return
end

dapui.setup(options)
```
Screenshot:
![Screen Shot 2022-02-16 at 4 57 56 PM](https://user-images.githubusercontent.com/6127369/154383626-2a59c588-baea-4a57-877b-3d14083fb24d.png)