### PR TITLE
fixup(watches): monitor expressions

### DIFF
--- a/lua/dapui/state.lua
+++ b/lua/dapui/state.lua
@@ -88,8 +88,8 @@ function UIState:attach(dap, listener_id)
             function() end
           )
         end
-      end
       self._variables[request.variablesReference] = response.variables
+      end
       self:_emit_refreshed(session)
     end
   end


### PR DESCRIPTION
additional error checking as a variable can become out of scope