### PR TITLE
Allow float numbers in size configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ require("dapui").setup({
   expand_lines = vim.fn.has("nvim-0.7"),
   -- Layouts define sections of the screen to place windows.
   -- The position can be "left", "right", "top" or "bottom".
-  -- The size specifies the height/width depending on position.
+  -- The size specifies the height/width depending on position. It can be an Int
+  -- or a Float. Integer specifies height/width directly (i.e. 20 lines/columns) while
+  -- Float value specifies percentage (i.e. 0.3 - 30% of available lines/columns)
   -- Elements are the elements shown in the layout (in order).
   -- Layouts are opened in order so that earlier layouts take priority in window sizing.
   layouts = {
@@ -80,7 +82,7 @@ require("dapui").setup({
         "stacks",
         "watches",
       },
-      size = 40,
+      size = 40, -- 40 columns
       position = "left",
     },
     {
@@ -88,7 +90,7 @@ require("dapui").setup({
         "repl",
         "console",
       },
-      size = 10,
+      size = 0.25, -- 25% of total lines
       position = "bottom",
     },
   },

--- a/lua/dapui/windows/init.lua
+++ b/lua/dapui/windows/init.lua
@@ -33,6 +33,7 @@ local function horizontal_layout(height, position, win_configs)
   end
 
   return WindowLayout({
+    layout_type = 'horizontal',
     area_state = { size = height },
     win_states = win_configs,
     get_win_size = api.nvim_win_get_width,
@@ -51,6 +52,7 @@ local function vertical_layout(width, position, win_configs)
   end
 
   return WindowLayout({
+    layout_type = 'vertical',
     area_state = { size = width },
     win_states = win_configs,
     get_win_size = api.nvim_win_get_height,

--- a/lua/dapui/windows/layout.lua
+++ b/lua/dapui/windows/layout.lua
@@ -31,8 +31,6 @@ function WindowLayout:open()
     return
   end
   local cur_win = api.nvim_get_current_win()
-  local initial_width = api.nvim_win_get_width(cur_win)
-  local initial_height = api.nvim_win_get_height(cur_win)
   for i, win_state in pairs(self.win_states) do
     local element = win_state.element
     local bufnr = api.nvim_create_buf(false, true)
@@ -46,7 +44,7 @@ function WindowLayout:open()
     -- REPL changes the buffer
     self.win_bufs[win_id] = api.nvim_win_get_buf(win_id)
   end
-  self:resize(initial_height, initial_width)
+  self:resize()
   api.nvim_set_current_win(cur_win)
   self.has_initial_open = true
 end
@@ -85,18 +83,21 @@ function WindowLayout:_area_size()
   return 0
 end
 
-function WindowLayout:resize(width, height)
+function WindowLayout:resize()
   if not self:is_open() then
     return
   end
 
   -- Detecting whether self.area_state.size is a float or int
-  local num, fraction = math.modf(self.area_state.size)
-  if num == 0 and fraction > 0 then
-    if self.layout_type == 'vertical' then
-      self.area_state.size = math.floor(height * self.area_state.size)
-    elseif self.layout_type == 'horizontal' then
-      self.area_state.size = math.floor(width * self.area_state.size)
+  if self.area_state.size < 1 then
+    if self.layout_type == "vertical" then
+      local left = 1
+      local right = vim.opt.columns:get()
+      self.area_state.size = math.floor((right - left) * self.area_state.size)
+    elseif self.layout_type == "horizontal" then
+      local top = vim.opt.tabline:get() == "" and 0 or 1
+      local bottom = vim.opt.lines:get() - (vim.opt.laststatus:get() > 0 and 2 or 1)
+      self.area_state.size = math.floor((bottom - top) * self.area_state.size)
     else
       error('Unknown layout type')
     end

--- a/lua/dapui/windows/layout.lua
+++ b/lua/dapui/windows/layout.lua
@@ -14,6 +14,7 @@ local util = require("dapui.util")
 ---@field win_bufs table<integer, integer>
 ---@field win_states table<integer,dapui.WinState>
 ---@field area_state dapui.AreaState
+---@field layout_type "horizontal" | "vertical"
 --
 ---@field open_index fun(index: number)
 ---@field get_win_size fun(win_id: integer): integer


### PR DESCRIPTION
Allows float numbers to be passed in **size** argument to use as percentage of a
window width/height.

With this pr, and using config presented below, you can always perfectly align bottom and side layout sections (_matched sections colored orange_):

![example](https://i.imgur.com/NiKBgBM.png "Title")

```lua
layouts = {
    {
        elements = {
            { id='breakpoints', size=0.30 }, -- Match this value
            { id='scopes',      size=0.45 },
            { id='watches',     size=0.25 },
        },
        size = 0.30,
        position = 'left',
    },
    {
        elements = { 'repl' },
        size = 0.30 -- With this value,
        position = 'bottom',
    },
},
```

