### PR TITLE
fix: fix `nil` index when setting var refs

### DIFF
--- a/lua/dapui/state.lua
+++ b/lua/dapui/state.lua
@@ -176,7 +176,6 @@ function UIState:_emit_refreshed(session)
 end
 
 function UIState:monitor(var_ref)
-  print("monitor", vim.inspect(var_ref))
   if var_ref then
     self._monitored_vars[var_ref] = (self._monitored_vars[var_ref] or 0) + 1
     util.with_session(function(session)

--- a/lua/dapui/state.lua
+++ b/lua/dapui/state.lua
@@ -177,10 +177,12 @@ end
 
 function UIState:monitor(var_ref)
   print("monitor", vim.inspect(var_ref))
-  self._monitored_vars[var_ref] = (self._monitored_vars[var_ref] or 0) + 1
-  util.with_session(function(session)
-    session:request("variables", { variablesReference = var_ref }, function() end)
-  end)
+  if var_ref then
+    self._monitored_vars[var_ref] = (self._monitored_vars[var_ref] or 0) + 1
+    util.with_session(function(session)
+      session:request("variables", { variablesReference = var_ref }, function() end)
+    end)
+  end
 end
 
 function UIState:step_number()

--- a/lua/dapui/state.lua
+++ b/lua/dapui/state.lua
@@ -176,6 +176,7 @@ function UIState:_emit_refreshed(session)
 end
 
 function UIState:monitor(var_ref)
+  print("monitor", vim.inspect(var_ref))
   self._monitored_vars[var_ref] = (self._monitored_vars[var_ref] or 0) + 1
   util.with_session(function(session)
     session:request("variables", { variablesReference = var_ref }, function() end)


### PR DESCRIPTION
When using `nvim-dap-ui` with `haskell-debug-adapter` I noticed that when watcher expressions were no longer available while stepping we'd crash loudly because of the ref coming into the `update` function being `nil`. This adds a check for non-`nil` and updates if we pass it.