### PR TITLE
add: null-handling to stacktrace callback

### DIFF
--- a/lua/dapui/state.lua
+++ b/lua/dapui/state.lua
@@ -108,7 +108,7 @@ function UIState:attach(dap, listener_id)
   end
 
   dap.listeners.after.stackTrace[listener_id] = function(session, err, response, request)
-    if not err then
+    if not err and request ~= nil then
       self._frames[request.threadId] = response.stackFrames
       self:_emit_refreshed(session)
     end


### PR DESCRIPTION
When using with [vscode-unity-debug](https://github.com/Unity-Technologies/vscode-unity-debug) request came null due to server returns empty stacktrace for other threads and this leads to nvim-dap-ui to pollute the UI with bunch of error messages. this PR fixes the repeated error messages which makes UI nearly unusable by adding null check in the stacktrace callback