### PR TITLE
fix(float): prevent error when opening empty float.

### DIFF
--- a/lua/dapui/render/line_hover.lua
+++ b/lua/dapui/render/line_hover.lua
@@ -60,6 +60,8 @@ function M.show()
     return
   end
 
+  if content_width <= 0 then return end
+
   local extmarks = api.nvim_buf_get_extmarks(
     buffer,
     namespace,

--- a/lua/dapui/windows/init.lua
+++ b/lua/dapui/windows/init.lua
@@ -114,7 +114,12 @@ function M.open_float(element, position, settings)
   local listener_id = element.name .. buf .. "float"
   render.loop.register_listener(listener_id, element.name, "render", function(rendered_buf, canvas)
     if rendered_buf == buf then
-      float_win:resize(settings.width or canvas:width(), settings.height or canvas:length())
+      local width = settings.width or canvas:width()
+      local height = settings.height or canvas:length()
+      if width <= 0 or height <= 0 then
+        return
+      end
+      float_win:resize(width, height)
     end
   end)
   render.loop.register_listener(listener_id, element.name, "close", function(closed_buf)


### PR DESCRIPTION
When I trigger float window when the content is empty it trigger error.
These are the changes I make to prevent it from happening.