### PR TITLE
fix: ignore setup if config.controls.element is empty

### DIFF
--- a/lua/dapui/init.lua
+++ b/lua/dapui/init.lua
@@ -150,7 +150,7 @@ function dapui.setup(user_config)
     end
   end
 
-  if config.controls.enabled then
+  if config.controls.enabled and config.controls.element ~= '' then
     local buf_name = buf_name_map[config.controls.element]
 
     local group = vim.api.nvim_create_augroup("DAPUIControls", {})


### PR DESCRIPTION
This allows to use the controls on anothers plugins, just using `require("dapui").controls()` and setting display controls element as empty, so the setup is made by the status line plugin.

This is how will look on the plugin that I maintain ([neoline.vim](https://github.com/adelarsq/neoline.vim)):

![image](https://user-images.githubusercontent.com/430272/196989109-fbcc2bfb-4df5-4523-9df4-4e2c2d3aa6b5.png)

@rcarriga Can you take a look? 
