### PR TITLE
fix: use vim.log.level enums for vim.notify lvls

### DIFF
--- a/lua/dapui/config/init.lua
+++ b/lua/dapui/config/init.lua
@@ -116,7 +116,7 @@ local function dep_warning(message)
   vim.schedule(function()
     if not dep_warnings[message] then
       dep_warnings[message] = true
-      vim.notify(message, "warn", {
+      vim.notify(message, vim.log.levels.WARN, {
         title = "nvim-dap-ui",
         on_open = function(win)
           vim.api.nvim_buf_set_option(vim.api.nvim_win_get_buf(win), "filetype", "markdown")

--- a/lua/dapui/init.lua
+++ b/lua/dapui/init.lua
@@ -124,7 +124,7 @@ function dapui.setup(user_config)
   local dap = require("dap")
   local render = require("dapui.render")
   if ui_state then
-    vim.notify("Setup called twice", "debug", {
+    vim.notify("Setup called twice", vim.log.levels.DEBUG, {
       title = "nvim-dap-ui",
       icon = " ",
     })

--- a/lua/dapui/render/canvas.lua
+++ b/lua/dapui/render/canvas.lua
@@ -233,7 +233,7 @@ function M._mapping(action)
   local line = vim.fn.line(".")
   local callbacks = _mappings[buffer][action][line]
   if not callbacks then
-    vim.notify("No " .. action .. " action for current line", "INFO")
+    vim.notify("No " .. action .. " action for current line", vim.log.levels.INFO)
     return
   end
   for _, callback in pairs(callbacks) do

--- a/lua/dapui/state.lua
+++ b/lua/dapui/state.lua
@@ -249,7 +249,8 @@ function UIState:set_variable(container_ref, variable, value)
       )
     else
       vim.notify(
-        "Debug server doesn't support setting " .. (variable.evaluateName or variable.name)
+        "Debug server doesn't support setting " .. (variable.evaluateName or variable.name),
+        vim.log.levels.WARN
       )
     end
   end)

--- a/lua/dapui/util.lua
+++ b/lua/dapui/util.lua
@@ -76,7 +76,7 @@ function M.jump_to_frame(frame, session, set_frame)
         return
       end
       if not response.body.content then
-        vim.notify("No source available for frame", "WARN")
+        vim.notify("No source available for frame", vim.log.levels.WARN)
         return
       end
       vim.api.nvim_buf_set_lines(buf, 0, 0, true, vim.split(response.body.content, "\n"))
@@ -88,7 +88,7 @@ function M.jump_to_frame(frame, session, set_frame)
   end
 
   if not source.path then
-    vim.notify("No source available for frame", "WARN")
+    vim.notify("No source available for frame", vim.log.levels.WARN)
   end
 
   local path = source.path

--- a/lua/dapui/windows/init.lua
+++ b/lua/dapui/windows/init.lua
@@ -20,7 +20,7 @@ local function create_win_states(win_configs)
       win_state.init_size = win_state.size
       win_states[#win_states + 1] = win_state
     else
-      vim.notify("nvim-dap-ui: Element " .. win_state.id .. " does not exist")
+      vim.notify("nvim-dap-ui: Element " .. win_state.id .. " does not exist", vim.log.levels.WARN)
     end
   end
   return win_states


### PR DESCRIPTION
Some notification alternative plugins enforce `vim.notify`'s expected type for its log level argument. So, we've replaced the string representations in this plugins to use the `vim.log.levels` enum representation instead.