### PR TITLE
Patch control highlight groups with background

### DIFF
--- a/lua/dapui/config/highlights.lua
+++ b/lua/dapui/config/highlights.lua
@@ -14,7 +14,7 @@ function M.patch_background(template_group)
   for _, hl_group in ipairs(control_hl_groups) do
     vim.cmd {
       cmd = "highlight",
-      args = {hl_group, string.format("guibg=#%06x", guibg)}
+      args = {hl_group, guibg and string.format("guibg=#%06x", guibg) or "guibg=NONE"}
     }
   end
 end

--- a/lua/dapui/config/highlights.lua
+++ b/lua/dapui/config/highlights.lua
@@ -1,5 +1,24 @@
 local M = {}
 
+local control_hl_groups = {
+  'DapUIPlayPause', 'DapUIRestart', 'DapUIStop', 'DapUIUnavailable',
+  'DapUIStepOver', 'DapUIStepInto', 'DapUIStepBack', 'DapUIStepOut',
+}
+
+---Applies the background color from the template highlight group to all
+---control icon highlight groups.
+---@param template_group string  Name of highlight group
+---@return nil
+function M.patch_background(template_group)
+  local guibg = vim.api.nvim_get_hl_by_name(template_group, true).background
+  for _, hl_group in ipairs(control_hl_groups) do
+    vim.cmd {
+      cmd = "highlight",
+      args = {hl_group, string.format("guibg=#%06x", guibg)}
+    }
+  end
+end
+
 function M.setup()
   vim.cmd("hi default link DapUIVariable Normal")
   vim.cmd("hi default DapUIScope guifg=#00F1F5")
@@ -31,12 +50,17 @@ function M.setup()
   vim.cmd("hi default DapUIPlayPause guifg=#A9FF68")
   vim.cmd("hi default DapUIRestart guifg=#A9FF68")
   vim.cmd("hi default DapUIUnavailable guifg=#424242")
+
+  M.patch_background("WinBar")
 end
+
 
 vim.cmd([[
   augroup DAPUIRefreshHighlights
     autocmd!
     autocmd ColorScheme * lua require('dapui.config.highlights').setup()
+    autocmd WinEnter *dap-repl* lua require('dapui.config.highlights').patch_background('WinBar')
+    autocmd WinLeave *dap-repl* lua require('dapui.config.highlights').patch_background('WinBarNC')
   augroup END
 ]])
 


### PR DESCRIPTION
Without a background the control icons leave ugly "gaps" inside the window bar. This PR makes it so that the highlight groups are patches with the current value of `WinBar` or `WinBarNC`, depending on whether the window is current or not. Autocommands are set up to re-patch the background every time the user enters of leaves the window.

![icons](https://user-images.githubusercontent.com/4954650/202782290-03f7f689-2e57-4e89-bba5-d345dd73b65c.png)
(green background intentionally exaggerated)

This assumes that the control icons are only in the REPL window. I don't know how we could handle the situation where a user has the control icons on more than one window. Supposed the user has control icons on the REPL and breakpoints window. If he leaves or enters the REPL the highlight groups are patched and the background flips in the breakpoints window as well because both share the same highlight groups.

I think the best solution would be to have a separate `winbar` for active and inactive windows and separate `*NC` highlight group variants for all the control highlight groups. This will be a more invasive change though, so I want to know your opinion first.