### PR TITLE
Implement separate *NC control highlight groups

### DIFF
--- a/lua/dapui/config/highlights.lua
+++ b/lua/dapui/config/highlights.lua
@@ -14,7 +14,7 @@ local function patch_background()
   if not vim.fn.has("nvim-0.8") then return end
 
   for _, suffix in pairs({"", "NC"}) do
-  	local template_group = string.format("WinBar%s", suffix)
+    local template_group = string.format("WinBar%s", suffix)
     local exists, hl = pcall(vim.api.nvim_get_hl_by_name, template_group, true)
 
     if exists then
@@ -64,17 +64,17 @@ function M.setup()
 
   -- Generate *NC variants of the control highlight groups
   if vim.fn.has("nvim-0.8") then
-  	for _, hl_group in pairs(control_hl_groups) do
+    for _, hl_group in pairs(control_hl_groups) do
       local guifg = vim.api.nvim_get_hl_by_name(hl_group, true).foreground
       vim.cmd {
-      	cmd = "highlight",
-      	args = {
+        cmd = "highlight",
+        args = {
           "default",
           string.format("%sNC", hl_group),
           string.format("guifg=#%06x", guifg)}
       }
-  	end
-  	patch_background()
+    end
+    patch_background()
   end
 end
 

--- a/lua/dapui/config/highlights.lua
+++ b/lua/dapui/config/highlights.lua
@@ -75,6 +75,10 @@ function M.setup()
       }
     end
     patch_background()
+  else
+    for _, hl_group in pairs(control_hl_groups) do
+      vim.cmd(string.format("hi default link %sNC %s", hl_group))
+    end
   end
 end
 

--- a/lua/dapui/config/highlights.lua
+++ b/lua/dapui/config/highlights.lua
@@ -1,27 +1,32 @@
 local M = {}
 
 local control_hl_groups = {
-  'DapUIPlayPause', 'DapUIRestart', 'DapUIStop', 'DapUIUnavailable',
-  'DapUIStepOver', 'DapUIStepInto', 'DapUIStepBack', 'DapUIStepOut',
+  "DapUIPlayPause", "DapUIRestart", "DapUIStop", "DapUIUnavailable",
+  "DapUIStepOver", "DapUIStepInto", "DapUIStepBack", "DapUIStepOut",
 }
 
 ---Applies the background color from the template highlight group to all
 ---control icon highlight groups.
----@param template_group string  Name of highlight group
 ---@return nil
-function M.patch_background(template_group)
-  -- Only exists for >= 0.8
-  local exists, hl = pcall(vim.api.nvim_get_hl_by_name, template_group, true)
-  if not exists then
-    return
-  end
+local function patch_background()
+  -- API function 'nvim_get_hl_by_name' and the ability to pass a table to
+  -- 'vim.cmd' only exist for >= 0.8
+  if not vim.fn.has("nvim-0.8") then return end
 
-  local guibg = hl.background
-  for _, hl_group in ipairs(control_hl_groups) do
-    vim.cmd {
-      cmd = "highlight",
-      args = {hl_group, guibg and string.format("guibg=#%06x", guibg) or "guibg=NONE"}
-    }
+  for _, suffix in pairs({"", "NC"}) do
+  	local template_group = string.format("WinBar%s", suffix)
+    local exists, hl = pcall(vim.api.nvim_get_hl_by_name, template_group, true)
+
+    if exists then
+      local guibg = hl.background and string.format("guibg=#%06x", hl.background) or "guibg=NONE"
+
+      for _, hl_group in ipairs(control_hl_groups) do
+        vim.cmd {
+          cmd = "highlight",
+          args = {string.format("%s%s", hl_group, suffix), guibg}
+        }
+      end
+    end
   end
 end
 
@@ -57,7 +62,20 @@ function M.setup()
   vim.cmd("hi default DapUIRestart guifg=#A9FF68")
   vim.cmd("hi default DapUIUnavailable guifg=#424242")
 
-  M.patch_background("WinBar")
+  -- Generate *NC variants of the control highlight groups
+  if vim.fn.has("nvim-0.8") then
+  	for _, hl_group in pairs(control_hl_groups) do
+      local guifg = vim.api.nvim_get_hl_by_name(hl_group, true).foreground
+      vim.cmd {
+      	cmd = "highlight",
+      	args = {
+          "default",
+          string.format("%sNC", hl_group),
+          string.format("guifg=#%06x", guifg)}
+      }
+  	end
+  	patch_background()
+  end
 end
 
 
@@ -65,8 +83,6 @@ vim.cmd([[
   augroup DAPUIRefreshHighlights
     autocmd!
     autocmd ColorScheme * lua require('dapui.config.highlights').setup()
-    autocmd WinEnter *dap-repl* lua require('dapui.config.highlights').patch_background('WinBar')
-    autocmd WinLeave *dap-repl* lua require('dapui.config.highlights').patch_background('WinBarNC')
   augroup END
 ]])
 


### PR DESCRIPTION
This is the continuation of #174, it fixes the remaining issue I mentioned over there. Now the background should work regardless of which window carries the control UI. I wish Vim's highlight system had a sort of "inheritance" feature that is between `link` and defining from scratch. Then we would not have to do this ugly highlight group patching.

![screenshots](https://user-images.githubusercontent.com/4954650/202848071-8c28314a-2be1-48f8-adc0-16935958c3e6.png)

For each of the control highlight groups there is now a corresponding highlight group with the same name plus `NC` as suffix. When entering or exiting the window which carries the support groups we reset the 'winbar' option such that the highlight groups are either normal or `*NC`.

The reason for this is that the user might have a different background for the highlight groups `WinBar` and `WinBarNC`. Whenever the user exits or enters a window, the editor will flip between these two groups, so we have to flip our custom highlight groups accordingly as well.