### PR TITLE
docs(README): fix link destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The default icons use [codicons](https://github.com/microsoft/vscode-codicons)
 It's recommended to use this [fork](https://github.com/ChristianChiarulli/neovim-codicons) which fixes alignment issues
 for the terminal. If your terminal doesn't support font fallback and you need to have icons included in font you use
 you can patch it via [Font Patcher](https://github.com/ryanoasis/nerd-fonts#option-8-patch-your-own-font). 
-Simple step by step guide [here](https://github.com/ryanoasis/nerd-fonts#option-8-patch-your-own-font).
+Simple step by step guide [here](https://github.com/mortepau/codicons.nvim#how-to-patch-fonts).
 
 Default settings:
 


### PR DESCRIPTION
By accident in #179 PR I duplicated links in readme file. This one fixes it