### PR TITLE
Add center option to float

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The optional settings can included the following keys:
 - `width: number` Width of the window
 - `height: number` Height of the window
 - `enter: boolean` Enter the floating window
+- `position: string` Position of floating window. `center` or `nil`
 
 Call the same function again while the window is open and the cursor will jump
 to the floating window. The REPL will automatically jump to the floating

--- a/lua/dapui/windows/init.lua
+++ b/lua/dapui/windows/init.lua
@@ -81,7 +81,7 @@ function M.setup(element_buffers)
       au!
       au BufWinEnter,BufWinLeave * lua require('dapui.windows')._force_buffers()
     augroup END
-  ]])
+  ]] )
   end
 end
 
@@ -96,6 +96,12 @@ function M.open_float(name, element, position, settings)
   if float_windows[name] then
     float_windows[name]:jump_to()
     return float_windows[name]
+  end
+  if settings.position == "center" then
+    local screen_w = vim.opt.columns:get()
+    local screen_h = vim.opt.lines:get() - vim.opt.cmdheight:get()
+    position.line = (screen_h - settings.height) / 2;
+    position.col = (screen_w - settings.width) / 2;
   end
   local buf = element.buffer()
   local float_win = require("dapui.windows.float").open_float({


### PR DESCRIPTION
Should solve #202 . 
Or better to make like `nui.nvim`? Which have `position` and `relative` option. More on [there](https://github.com/MunifTanjim/nui.nvim/tree/main/lua/nui/popup)