### PR TITLE
Add default mapping keybindings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,6 @@ Plug 'rcarriga/nvim-dap-ui'
 use { "rcarriga/nvim-dap-ui", requires = {"mfussenegger/nvim-dap"} }
 ```
 
-## Configuration
-
-nvim-dap-ui is built on the idea of "elements". These elements are windows
-which provide different features.
-
-Elements are grouped into layouts which can be placed on any side of the screen.
-There can be any number of layouts, containing whichever elements desired.
-
-Elements can also be displayed temporarily in a floating window.
-
-See `:h dapui.setup()` for configuration options and defaults
-
 It is highly recommended to use [neodev.nvim](https://github.com/folke/neodev.nvim) to enable type checking for nvim-dap-ui to get
 type checking, documentation and autocompletion for all API functions.
 
@@ -57,6 +45,28 @@ The default icons use [codicons](https://github.com/microsoft/vscode-codicons).
 It's recommended to use this [fork](https://github.com/ChristianChiarulli/neovim-codicons) which fixes alignment issues
 for the terminal. If your terminal doesn't support font fallback and you need to have icons included in your font, you can patch it via [Font Patcher](https://github.com/ryanoasis/nerd-fonts#option-8-patch-your-own-font). 
 There is a simple step by step guide [here](https://github.com/mortepau/codicons.nvim#how-to-patch-fonts).
+
+## Configuration
+
+nvim-dap-ui is built on the idea of "elements". These elements are windows
+which provide different features.
+
+Elements are grouped into layouts which can be placed on any side of the screen.
+There can be any number of layouts, containing whichever elements desired.
+
+Elements can also be displayed temporarily in a floating window.
+
+Each element has a set of *mappings* for element-specific possible actions, detailed below for each element.
+The total set of actions/mappings and their default shortcuts are:
+- `edit`: `e`
+- `expand`: `<CR>` or left click
+- `open`: `o`
+- `remove`: `d`
+- `repl`: `r`
+- `toggle`: `t`
+
+See `:h dapui.setup()` for configuration options and defaults.
+
 
 ### Variable Scopes
 


### PR DESCRIPTION
I really like this plugin but found it a little difficult to get started. I have a suggestion here which I think is important: the README does not actually define what a "Mapping" is or describe how to activate them, and it required reading a lot of the details of the docs for me to understand. I think the main README should have a minimal self-contained description of how to actually use the bindings in the plugin, and I added a short description. I also took the liberty of moving the discussion on some recommended dependencies into the "Installation" section.