### PR TITLE
Using vim.opt.winhighlight:append

### DIFF
--- a/lua/dapui/render/line_hover.lua
+++ b/lua/dapui/render/line_hover.lua
@@ -102,7 +102,9 @@ function M.show()
     window_id = api.nvim_open_win(hover_buf, false, win_opts)
     buf_wins[buffer] = window_id
 
-    api.nvim_win_set_option(window_id, "winhighlight", "NormalFloat:Normal")
+    api.nvim_win_call(window_id, function()
+      vim.opt.winhighlight:append({ NormalFloat = "Normal" })
+    end)
   end
 
   orig_col = orig_col - 1 -- Working with 0-based index now

--- a/lua/dapui/windows/layout.lua
+++ b/lua/dapui/windows/layout.lua
@@ -184,7 +184,9 @@ function WindowLayout:_init_win_settings(win)
   for key, val in pairs(win_settings) do
     api.nvim_win_set_option(win, key, val)
   end
-  vim.fn.setwinvar(win, "&winhl", "Normal:DapUINormal,EndOfBuffer:DapUIEndOfBuffer")
+  api.nvim_win_call(win, function()
+    vim.opt.winhighlight:append({ Normal = "DapUINormal", EndOfBuffer = "DapUIEndOfBuffer" })
+  end)
 end
 
 function WindowLayout:new(layout)


### PR DESCRIPTION
So as to not clobber other custom window highlights.

I highlight `NormalNC` to dim the other windows that are not focused, and for the exceptions I append `NormalNC:NONE` to `winhighlight`. `nvim-dap-ui` windows are such cases (to wit, windows with special buffers, i.e., `buftype` is not empty), but the plugin overwrites that.

I propose using `vim.opt` and override only what is necessary to deliver the desired look and feel, while preserving other highlights.