### PR TITLE
fix: show thrown errors when an async-wrapped function fails

### DIFF
--- a/lua/dapui/init.lua
+++ b/lua/dapui/init.lua
@@ -144,7 +144,7 @@ function dapui.float_element(elem_name, args)
         open_float = nil
       end)
     end
-  end)
+  end, util.err_handler)
 end
 
 local prev_expr = nil
@@ -195,7 +195,7 @@ function dapui.eval(expr, args)
         open_float = nil
       end)
     end
-  end)
+  end, util.err_handler)
 end
 
 --- Update the config.render settings and re-render windows
@@ -207,7 +207,7 @@ function dapui.update_render(update)
     for _, elem in pairs(elements) do
       elem.render()
     end
-  end)
+  end, util.err_handler)
 end
 
 local function keep_cmdheight(cb)
@@ -398,7 +398,7 @@ function dapui.register_element(name, element)
   windows.register_element(name, element)
   async.run(function()
     element.render()
-  end)
+  end, util.err_handler)
 end
 
 return dapui

--- a/lua/dapui/util.lua
+++ b/lua/dapui/util.lua
@@ -234,6 +234,14 @@ function M.format_error(error)
   return formatted
 end
 
+function M.err_handler(ok, err)
+  if ok then
+    return
+  end
+
+  M.notify(err, vim.log.levels.ERROR)
+end
+
 function M.partial(func, ...)
   local args = { ... }
   return function(...)


### PR DESCRIPTION
Coroutine-wrapped (async.run) functions will fail silently if any error
happens. Instead, the error should be displayed and notified to users.

For example,

```
:lua require"dapui".float_element("notexist")
```

fails silently, but it could instead show a more informative error:
```
.../nvim-dap-ui/lua/dapui/init.lua:137: attempt to index local 'elem' (a nil value)
stack traceback:
        .../nvim-dap-ui/lua/dapui/init.lua: in function <.../nvim-dap-ui/lua/dapui/init.lua
:125>
```