### PR TITLE
fix(highlights): Correct DapUINormalFloat to DapUIFloatNormal

### DIFF
--- a/lua/dapui/windows/float.lua
+++ b/lua/dapui/windows/float.lua
@@ -99,7 +99,7 @@ function M.open_float(settings)
   local content_window = api.nvim_open_win(content_buffer, false, opts)
 
   local output_win_id = api.nvim_win_get_number(content_window)
-  vim.fn.setwinvar(output_win_id, "&winhl", "Normal:DapUINormalFloat,FloatBorder:DapUIFloatBorder")
+  vim.fn.setwinvar(output_win_id, "&winhl", "Normal:DapUIFloatNormal,FloatBorder:DapUIFloatBorder")
   vim.api.nvim_win_set_option(content_window, "wrap", false)
 
   return Float:new(content_window, position)


### PR DESCRIPTION
It looks like in https://github.com/rcarriga/nvim-dap-ui/commit/d7a9f032e7e45b37d778ef83e3d412566ba97cb5, the use of `DapUIFloatNormal` was introduced, but two different names were used (`DapUIFloatNormal` and `DapUINormalFloat`).

This fix is correcting the names to both be `DapUIFloatNormal` as it seems to follow the general naming convention used