### PR TITLE
fix(frames): fix fetching stack frame ids

### DIFF
--- a/lua/dapui/components/frames.lua
+++ b/lua/dapui/components/frames.lua
@@ -12,13 +12,12 @@ return function(client, send_ready)
     ---@async
     ---@param canvas dapui.Canvas
     render = function(canvas, thread_id, show_subtle, indent)
-      local success, response = pcall(client.request.stackTrace, { threadId = thread_id })
       local current_frame_id = nil
 
-      if not success then
+      local frames = vim.tbl_get(require("dap").session(), 'threads', thread_id, 'frames')
+      if not frames then
         return
       end
-      local frames = response.stackFrames
 
       if not show_subtle then
         frames = vim.tbl_filter(function(frame)


### PR DESCRIPTION
Fixes #303

It's rather a workaround than an ultimate solution, but shows that #303 can be fixed on dap-ui side.