### PR TITLE
docs(README): improve suggested listener setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,16 @@ You can use nvim-dap events to open and close the windows automatically (`:help 
 
 ```lua
 local dap, dapui = require("dap"), require("dapui")
-dap.listeners.after.event_initialized["dapui_config"] = function()
+dap.listeners.before.attach.dapui_config = function()
   dapui.open()
 end
-dap.listeners.before.event_terminated["dapui_config"] = function()
+dap.listeners.before.launch.dapui_config = function()
+  dapui.open()
+end
+dap.listeners.before.event_terminated.dapui_config = function()
   dapui.close()
 end
-dap.listeners.before.event_exited["dapui_config"] = function()
+dap.listeners.before.event_exited.dapui_config = function()
   dapui.close()
 end
 ```


### PR DESCRIPTION
The event_initialized used previously will sometimes fire despite debugging not being able to start.

For me this is reproducible by pressing ESC on the prompt for a debugee binary path with codelldb.