### PR TITLE
fix: delay for keymaps

### DIFF
--- a/lua/dapui/util.lua
+++ b/lua/dapui/util.lua
@@ -206,9 +206,9 @@ end
 function M.apply_mapping(mappings, func, buffer)
   for _, key in pairs(mappings) do
     if type(func) ~= "string" then
-      vim.api.nvim_buf_set_keymap(buffer, "n", key, "", { noremap = true, callback = func })
+      vim.api.nvim_buf_set_keymap(buffer, "n", key, "", { noremap = true, callback = func, nowait = true })
     else
-      vim.api.nvim_buf_set_keymap(buffer, "n", key, func, { noremap = true })
+      vim.api.nvim_buf_set_keymap(buffer, "n", key, func, { noremap = true, nowait = true })
     end
   end
 end


### PR DESCRIPTION
If you have a keymap for `qq`, then pressing `q` will result in a small delay, since vim waits to see whether you are pressing `q` or `qq`.

This PR fixes the issue by adding [nowait](https://neovim.io/doc/user/map.html#%3Amap-nowait) to the keymaps on creation.