### PR TITLE
fix: make sure to clear prompt_func after editing variable

### DIFF
--- a/lua/dapui/components/variables.lua
+++ b/lua/dapui/components/variables.lua
@@ -82,9 +82,9 @@ return function(client, send_ready)
         canvas:add_mapping("edit", function()
           prompt_func = function(new_value)
             async.run(function()
-              client.lib.set_variable(parent_ref, variable, new_value)
               prompt_func = nil
               prompt_fill = nil
+              client.lib.set_variable(parent_ref, variable, new_value)
               send_ready()
             end)
           end


### PR DESCRIPTION
fixes issue https://github.com/rcarriga/nvim-dap-ui/issues/325

---

`prompt_func` is not being reset to `nil` when editing a variable. This causes `canvas:set_prompt()` to get trigger on every other action, like `expand`.