### PR TITLE
Fix highlights on expanded lines. 

### DIFF
--- a/lua/dapui/render/line_hover.lua
+++ b/lua/dapui/render/line_hover.lua
@@ -63,9 +63,9 @@ function M.show()
   end
 
   if
-      content_width <= 0
-      or content_width
-      < vim.fn.winwidth(0) - vim.fn.getwininfo(vim.api.nvim_get_current_win())[1].textoff - (orig_col + 1)
+    content_width <= 0
+    or content_width
+      < vim.fn.winwidth(0) - vim.fn.getwininfo(vim.api.nvim_get_current_win())[1].textoff - orig_col - 1
   then
     return
   end


### PR DESCRIPTION
- Don't pass invalid `ns_id` key to `nvim_buf_set_extmark` opts - it resulted with error (silenced by using `pcall`)
- Fix column number in the end of range of copied extmark
- Quick return if window id is invalid
- fix revealed line/column issues (related to different offset on `vim.fn` and `vim.api` methods)
- notify (debug level) about some errors (maybe not needed after above fixes)