### PR TITLE
feat(float_element): show name of float element as window title

### DIFF
--- a/lua/dapui/init.lua
+++ b/lua/dapui/init.lua
@@ -119,6 +119,7 @@ end
 ---@field width integer Fixed width of window
 ---@field height integer Fixed height of window
 ---@field enter boolean Whether or not to enter the window after opening
+---@field title string Title of window
 
 --- Open a floating window containing the desired element.
 ---
@@ -140,8 +141,12 @@ function dapui.float_element(elem_name, args)
     end
     local elem = elements[elem_name]
     elem.render()
-    args =
-      vim.tbl_deep_extend("keep", args or {}, elem.float_defaults and elem.float_defaults() or {})
+    args = vim.tbl_deep_extend(
+      "keep",
+      args or {},
+      elem.float_defaults and elem.float_defaults() or {},
+      { title = elem_name }
+    )
     nio.scheduler()
     open_float = require("dapui.windows").open_float(elem_name, elem, position, args)
     if open_float then

--- a/lua/dapui/windows/float.lua
+++ b/lua/dapui/windows/float.lua
@@ -4,7 +4,7 @@ local config = require("dapui.config")
 
 local Float = { win_id = nil, listeners = { close = {} }, position = {} }
 
-local function create_opts(content_width, content_height, position)
+local function create_opts(content_width, content_height, position, title)
   local line_no = position.line
   local col_no = position.col
 
@@ -35,6 +35,8 @@ local function create_opts(content_width, content_height, position)
     height = height,
     style = "minimal",
     border = border,
+    title = title,
+    title_pos = title and "center",
   }
 end
 
@@ -90,11 +92,12 @@ end
 --   Optional:
 --     buffer
 --     position
+--     title
 function M.open_float(settings)
   local line_no = vim.fn.screenrow()
   local col_no = vim.fn.screencol()
   local position = settings.position or { line = line_no, col = col_no }
-  local opts = create_opts(settings.width, settings.height, position)
+  local opts = create_opts(settings.width, settings.height, position, settings.title)
   local content_buffer = settings.buffer or api.nvim_create_buf(false, true)
   local content_window = api.nvim_open_win(content_buffer, false, opts)
 

--- a/lua/dapui/windows/init.lua
+++ b/lua/dapui/windows/init.lua
@@ -135,6 +135,7 @@ function M.open_float(name, element, position, settings)
     width = settings.width or 1,
     position = position,
     buffer = buf,
+    title = settings.title,
   })
 
   local resize = function()


### PR DESCRIPTION
It's useful when opening a window that contains nothing to distinguish elements.
![image](https://github.com/rcarriga/nvim-dap-ui/assets/61115159/4127bcc4-6ff8-4995-99bc-92c54b07a562)

I can add an option to opt for that if needed.
