### PR TITLE
Fix edit variables

### DIFF
--- a/lua/dapui/client/lib.lua
+++ b/lua/dapui/client/lib.lua
@@ -53,7 +53,7 @@ return function(client)
 
   ---@param variable dapui.types.Variable
   function client_lib.set_variable(container_ref, variable, value)
-    local err = pcall(function()
+    local ok, err = pcall(function()
       if client.session.capabilities.supportsSetExpression and variable.evaluateName then
         local frame_id = client.session.current_frame and client.session.current_frame.id
         client.request.setExpression({
@@ -74,7 +74,7 @@ return function(client)
         )
       end
     end)
-    if err then
+    if not ok then
       util.notify(util.format_error(err))
     end
   end


### PR DESCRIPTION
Fixes #349

As reported by the linked issue, editing variables shows an error, although it works as expected. The problem was that it wasn't capturing the first `pcall` return value (aka success) to figure out whether the `pcall` worked or not, and then, yes, use its second return value (aka `result`) to eventually handle the error.
More info: http://www.lua.org/manual/5.1/manual.html#pdf-pcall