### PR TITLE
fix: replace tbl_flatten to flatten():totable()

### DIFF
--- a/lua/dapui/logging.lua
+++ b/lua/dapui/logging.lua
@@ -39,7 +39,7 @@ function Logger.new(filename, opts)
   end)()
 
   local function path_join(...)
-    return table.concat(vim.tbl_flatten({ ... }), path_sep)
+    return table.concat(vim.iter({ ... }):flatten():totable(), path_sep)
   end
 
   logger._level = opts.level or config.log_level

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -11,15 +11,15 @@ H.pattern_sets = {
   -- Determine if line is a function definition. Captures function name and
   -- arguments. For reference see '2.5.9 – Function Definitions' in Lua manual.
   afterline_fundef = {
-    "%s*function%s+(%S-)(%b())", -- Regular definition
-    "^local%s+function%s+(%S-)(%b())", -- Local definition
-    "^(%S+)%s*=%s*function(%b())", -- Regular assignment
+    "%s*function%s+(%S-)(%b())",           -- Regular definition
+    "^local%s+function%s+(%S-)(%b())",     -- Local definition
+    "^(%S+)%s*=%s*function(%b())",         -- Regular assignment
     "^local%s+(%S+)%s*=%s*function(%b())", -- Local assignment
   },
 
   -- Determine if line is a general assignment
   afterline_assign = {
-    "^(%S-)%s*=", -- General assignment
+    "^(%S-)%s*=",         -- General assignment
     "^local%s+(%S-)%s*=", -- Local assignment
   },
 
@@ -108,7 +108,7 @@ H.default_input = function()
     table.insert(res, files)
   end
 
-  return vim.tbl_flatten(res)
+  return vim.iter(res):flatten():totable()
 end
 
 H.default_output = function()
@@ -303,7 +303,7 @@ H.toc_insert = function(s)
     toc_entry:clear_lines()
   end
 
-  for _, l in ipairs(vim.tbl_flatten(toc_lines)) do
+  for _, l in ipairs(vim.iter(toc_lines):flatten():totable()) do
     s:insert(l)
   end
 end
@@ -626,7 +626,7 @@ H.collect_strings = function(x)
     end
   end, x)
   -- Flatten to only have strings and not table of strings (from `vim.split`)
-  return vim.tbl_flatten(res)
+  return vim.iter(res):flatten():totable()
 end
 
 H.file_read = function(path)
@@ -733,7 +733,6 @@ minidoc.generate(
         )
       end,
       section_post = function(section)
-
         for i, line in ipairs(section) do
           if type(line) == "string" then
             if string.find(line, "^```") then
@@ -743,7 +742,6 @@ minidoc.generate(
             end
           end
         end
-
       end,
       sections = {
         ["@generic"] = function(s)


### PR DESCRIPTION
Deprecation warnings in v0.10 and v11 nightlies

```
vim.tbl_flatten is deprecated, use vim.iter(…):flatten():totable() instead. :help deprecated
Feature will be removed in Nvim 0.12
```