### PR TITLE
fix: scrolling incorrect window

### DIFF
--- a/lua/dapui/elements/console.lua
+++ b/lua/dapui/elements/console.lua
@@ -37,7 +37,9 @@ return function()
       })
       nio.api.nvim_buf_attach(console_buf, false, {
         on_lines = function(_, _, _, _, _, _)
-          if autoscroll and vim.fn.mode() == "n" then
+          local active_buf = nio.api.nvim_win_get_buf(0)
+
+          if autoscroll and vim.fn.mode() == "n" and active_buf == console_buf then
             vim.cmd("normal! G")
           end
         end,


### PR DESCRIPTION
Hello,

I'm integrating with this window and unfortunately auto-scroll breaks the integration because it doesn't check if the console buffer is active. I added this improvement.

Resolves: https://github.com/wojciech-kulik/xcodebuild.nvim/issues/148