### PR TITLE
Fix output window incorrectly resizing

### DIFF
--- a/lua/dapui/init.lua
+++ b/lua/dapui/init.lua
@@ -248,7 +248,6 @@ function dapui.close(args)
     end
     for i, win_layout in ipairs(windows.layouts) do
       if not layout or layout == i then
-        win_layout:update_sizes()
         win_layout:close()
       end
     end


### PR DESCRIPTION
Often, when opening and closing the UI, the output window gets progressively smaller.
This seems to be caused by the second call to win_layout:update_sizes detecting different total width for the bottom panel in the default configuration.
If the vertical layout has already been closed, the command windows is resized (by vim, not much that can be done in that case) and the win_size computation is incorrect. The next time dapui is opened the command window has a larger percentage of the layout.
The fix seems to be updating the sizes before closing any layout, which as far as I understand is already done few lines above.
I have tested it with my configuration, but if there is any edge case (in particular with args) I'd be happy to revisit this PR.