### PR TITLE
Add documentation for floating window position param

### DIFF
--- a/doc/nvim-dap-ui.txt
+++ b/doc/nvim-dap-ui.txt
@@ -137,6 +137,7 @@ Fields~
 {height} `(integer)` Fixed height of window
 {enter} `(boolean)` Whether or not to enter the window after opening
 {title} `(string)` Title of window
+{position} `("center")` Position of floating window
 
                                                          *dapui.float_element()*
 `float_element`({elem_name}, {args})

--- a/lua/dapui/init.lua
+++ b/lua/dapui/init.lua
@@ -120,6 +120,7 @@ end
 ---@field height integer Fixed height of window
 ---@field enter boolean Whether or not to enter the window after opening
 ---@field title string Title of window
+---@field position "center" Position of floating window
 
 --- Open a floating window containing the desired element.
 ---


### PR DESCRIPTION
Add documentation for the floating window param introduced in #215 

After seeing a mention that the docs were not modified manually but rather generated with I script, I added the field to the class and generated the docs using the script provided in scripts/docgen