### PR TITLE
fix: request thread stack trace if client hasn't reported it

### DIFF
--- a/lua/dapui/components/frames.lua
+++ b/lua/dapui/components/frames.lua
@@ -26,6 +26,10 @@ return function(client, send_ready)
 
       local frames = threads[thread_id].frames
       if not frames then
+        local success, response = pcall(client.request.stackTrace, { threadId = thread_id })
+        frames = success and response.stackFrames
+      end
+      if not frames then
         return
       end
 


### PR DESCRIPTION
Fixes: https://github.com/rcarriga/nvim-dap-ui/issues/387 (see this issue for more context) 

Request thread stack trace in case Debug Adapter hasn't reported it. This makes it possible to see stack traces for every thread when debugging multi-threaded application, which apparently was broken for around half a year due to regression introduced by: https://github.com/rcarriga/nvim-dap-ui/commit/a62e86b124a94ad1f34a3f936ea146d00aa096d1

Asking each thread for a stack trace can be a bit slow though (depending on adapter/debugger and project size). For example when debugging something like Unreal Engine Editor which is huge and runs with around 50+ threads, the difference in response times is noticeable. **It would be nice to have an option for disabling this feature. I can add it right after this PR goes through.**

I tested it manually on my Linux machine with NVIM v0.10.1, and it works just fine with GDB and vscode-cpptools

### before (2nd thread missing the stack trace)
![image](https://github.com/user-attachments/assets/b551d55b-4dfe-4c8d-b641-934e7f60e010)

### after (both threads display the stack trace)
![image](https://github.com/user-attachments/assets/a5b521cf-ed31-4696-881e-40ca3aac0a14)