### PR TITLE
fix(dapui): opening float element requires a debug session

### DIFF
--- a/lua/dapui/init.lua
+++ b/lua/dapui/init.lua
@@ -129,6 +129,10 @@ end
 ---@param args? dapui.FloatElementArgs
 function dapui.float_element(elem_name, args)
   nio.run(function()
+    if not dap.session() then
+      util.notify("No active debug session", vim.log.levels.WARN)
+      return
+    end
     if open_float then
       return open_float:jump_to()
     end


### PR DESCRIPTION
Fix Float Element Can Be Open While There Is No dap Session Alive #398 

This fix will detect debug session before opening a float element when executing `require("dapui").float_element()`. If there is no debug session found it will stop execution and prompt a warning "No active debug session"