### PR TITLE
Fix performance issues by allowing Scopes to be disabled

### DIFF
--- a/lua/dapui/components/scopes.lua
+++ b/lua/dapui/components/scopes.lua
@@ -2,12 +2,27 @@ local config = require("dapui.config")
 ---@param client dapui.DAPClient
 return function(client, send_ready)
   local render_vars = require("dapui.components.variables")(client, send_ready)
+  local closed_scopes = {}
+
+  ---@param scope dapui.types.Scope
+  local function scope_prefix(scope)
+    if scope.indexedVariables == 0 then
+      return " "
+    end
+    return config.icons[closed_scopes[scope.name] and "collapsed" or "expanded"]
+  end
 
   ---@type dapui.types.Scope[] | nil
   local _scopes
   client.listen.scopes(function(args)
     if args.response then
       _scopes = args.response.scopes
+      -- when new scopes are parsed, automatically disable the scopes that are too expensive to render
+      for _, scope in ipairs(_scopes) do
+        if scope.expensive then
+          closed_scopes[scope.name] = true
+        end
+      end
     end
     send_ready()
   end)
@@ -28,8 +43,23 @@ return function(client, send_ready)
         return
       end
       for i, scope in pairs(scopes) do
-        canvas:write({ { scope.name, group = "DapUIScope" }, ":\n" })
-        render_vars.render(canvas, scope.name, scope.variablesReference, config.render.indent)
+        canvas:add_mapping("expand", function()
+          closed_scopes[scope.name] = not closed_scopes[scope.name]
+          send_ready()
+        end)
+
+        canvas:write({
+          { scope_prefix(scope), group = "DapUIDecoration" },
+          " ",
+          { scope.name, group = "DapUIScope" },
+          { ":\n" },
+        })
+
+        -- only render expanded scopes to save resources
+        if not closed_scopes[scope.name] then
+          render_vars.render(canvas, scope.name, scope.variablesReference, config.render.indent)
+        end
+
         if i < #scopes then
           canvas:write("\n")
         end

--- a/tests/unit/elements/scopes_spec.lua
+++ b/tests/unit/elements/scopes_spec.lua
@@ -76,11 +76,11 @@ describe("scopes element", function()
   a.it("renders initial lines", function()
     local lines = nio.api.nvim_buf_get_lines(buf, 0, -1, false)
     assert.same({
-      "Locals:",
+      " Locals:",
       "   a number = 1",
       "  b number = 2",
       "",
-      "Globals:",
+      " Globals:",
       "   CONST_A boolean = true",
     }, lines)
   end)
@@ -88,7 +88,8 @@ describe("scopes element", function()
   a.it("renders initial highlights", function()
     local formatted = tests.util.get_highlights(buf)
     assert.same({
-      { "DapUIScope", 0, 0, 0, 6 },
+      { "DapUIDecoration", 0, 0, 0, 3 },
+      { "DapUIScope", 0, 4, 0, 10 },
       { "DapUIDecoration", 1, 1, 1, 2 },
       { "DapUIVariable", 1, 3, 1, 4 },
       { "DapUIType", 1, 5, 1, 11 },
@@ -97,7 +98,8 @@ describe("scopes element", function()
       { "DapUIVariable", 2, 5, 2, 6 },
       { "DapUIType", 2, 7, 2, 13 },
       { "DapUIValue", 2, 16, 2, 17 },
-      { "DapUIScope", 4, 0, 4, 7 },
+      { "DapUIDecoration", 4, 0, 4, 3 },
+      { "DapUIScope", 4, 4, 4, 11 },
       { "DapUIDecoration", 5, 1, 5, 2 },
       { "DapUIVariable", 5, 3, 5, 10 },
       { "DapUIType", 5, 11, 5, 18 },
@@ -112,12 +114,12 @@ describe("scopes element", function()
       nio.sleep(10)
       local lines = nio.api.nvim_buf_get_lines(buf, 0, -1, false)
       assert.same({
-        "Locals:",
+        " Locals:",
         "   a number = 1",
         "  b number = 2",
         "    c string = '3'",
         "",
-        "Globals:",
+        " Globals:",
         "   CONST_A boolean = true",
       }, lines)
     end)
@@ -127,7 +129,8 @@ describe("scopes element", function()
       nio.sleep(10)
       local formatted = tests.util.get_highlights(buf)
       assert.same({
-        { "DapUIScope", 0, 0, 0, 6 },
+        { "DapUIDecoration", 0, 0, 0, 3 },
+        { "DapUIScope", 0, 4, 0, 10 },
         { "DapUIDecoration", 1, 1, 1, 2 },
         { "DapUIVariable", 1, 3, 1, 4 },
         { "DapUIType", 1, 5, 1, 11 },
@@ -140,7 +143,8 @@ describe("scopes element", function()
         { "DapUIVariable", 3, 4, 3, 5 },
         { "DapUIType", 3, 6, 3, 12 },
         { "DapUIValue", 3, 15, 3, 18 },
-        { "DapUIScope", 5, 0, 5, 7 },
+        { "DapUIDecoration", 5, 0, 5, 3 },
+        { "DapUIScope", 5, 4, 5, 11 },
         { "DapUIDecoration", 6, 1, 6, 2 },
         { "DapUIVariable", 6, 3, 6, 10 },
         { "DapUIType", 6, 11, 6, 18 },


### PR DESCRIPTION
### The Problem

Currently, the "Scopes" widget renders all variables for every scope. However, this can become problematic when dealing with large global scopes, particularly when importing frameworks like React. This results in noticeable performance degradation, as mentioned in [this Reddit post I made](https://www.reddit.com/r/neovim/comments/1foy8fp/why_is_js_neovim_debugger_so_slow_compared_with/).

### Proposed Solution

To address this issue, I’ve made the "Scopes" widget expandable. When a scope is collapsed, it is not rendered, thereby improving performance. Additionally, I’ve utilized the `expensive` flag from the [Debugger Adapter Protocol `Scope` type](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Scope) to automatically collapse scopes that are too resource-intensive to render.

Users can still manually expand these scopes, even though this may takea few seconds.

In my opinion this provides a better debugging experience, as you no longer have to wait a few seconds every time you jump between breakpoints.