### PR TITLE
fix(dapui): allow certain elements to float without active session

### DIFF
--- a/doc/nvim-dap-ui.txt
+++ b/doc/nvim-dap-ui.txt
@@ -239,6 +239,8 @@ buffer can change over repeated calls
 {float_defaults?} `(fun(): dapui.FloatElementArgs)` Default settings for
 floating windows. Useful for element windows which should be larger than
 their content
+{allow_without_session?} `(boolean)` Allows floating the element when
+there is no active debug session
 
                                                       *dapui.register_element()*
 `register_element`({name}, {element})

--- a/lua/dapui/elements/breakpoints.lua
+++ b/lua/dapui/elements/breakpoints.lua
@@ -15,7 +15,9 @@ return function(client)
   --- Mappings:
   --- - `open`: Jump to the location the breakpoint is set
   --- - `toggle`: Enable/disable the selected breakpoint
-  dapui.elements.breakpoints = {}
+  dapui.elements.breakpoints = {
+    allow_without_session = true,
+  }
 
   local send_ready = util.create_render_loop(function()
     dapui.elements.breakpoints.render()

--- a/lua/dapui/elements/watches.lua
+++ b/lua/dapui/elements/watches.lua
@@ -19,7 +19,10 @@ return function(client)
   --- - `remove`: Remove the watched expression.
   --- - `edit`: Edit an expression or set the value of a child variable.
   --- - `repl`: Send expression to REPL
-  dapui.elements.watches = {}
+  dapui.elements.watches = {
+    allow_without_session = true,
+  }
+
   local send_ready = util.create_render_loop(function()
     dapui.elements.watches.render()
   end)

--- a/lua/dapui/init.lua
+++ b/lua/dapui/init.lua
@@ -130,7 +130,16 @@ end
 ---@param args? dapui.FloatElementArgs
 function dapui.float_element(elem_name, args)
   nio.run(function()
-    if not dap.session() then
+    elem_name = elem_name or query_elem_name()
+    if not elem_name then
+      return
+    end
+    local elem = elements[elem_name]
+    if not elem then
+      util.notify("No such element: " .. elem_name, vim.log.levels.ERROR)
+      return
+    end
+    if not elem.allow_without_session and not dap.session() then
       util.notify("No active debug session", vim.log.levels.WARN)
       return
     end
@@ -140,11 +149,6 @@ function dapui.float_element(elem_name, args)
     local line_no = nio.fn.screenrow()
     local col_no = nio.fn.screencol()
     local position = { line = line_no, col = col_no }
-    elem_name = elem_name or query_elem_name()
-    if not elem_name then
-      return
-    end
-    local elem = elements[elem_name]
     elem.render()
     args = vim.tbl_deep_extend(
       "keep",
@@ -402,6 +406,8 @@ dapui.elements = setmetatable({}, {
 ---@field float_defaults? fun(): dapui.FloatElementArgs Default settings for
 --- floating windows. Useful for element windows which should be larger than
 --- their content
+---@field allow_without_session boolean Allows floating the element when
+--- there is no active debug session
 
 --- Registers a new element that can be used within layouts or floating windows
 ---@param name string Name of the element


### PR DESCRIPTION
[#339 ](https://github.com/rcarriga/nvim-dap-ui/pull/399) forbids floating all elements without an active debug session. But using `breakpoints` and `watches` elements makes perfect sense in-between sessions (i.e. jumping/toggling/removing breakpoints, adding/editing watches), and it breaks such use cases.

This adds `allow_without_session` option to Element, sets it for `breakpoints` and `watches` built-in elements, and limits the introduced behavior to the elements with said option unset.