### PR TITLE
fix(float_element): auto detect size for centered floating element

### DIFF
--- a/lua/dapui/windows/float.lua
+++ b/lua/dapui/windows/float.lua
@@ -53,8 +53,11 @@ function Float:listen(event, callback)
   self.listeners[event][#self.listeners[event] + 1] = callback
 end
 
-function Float:resize(width, height)
-  local opts = create_opts(width, height, self.position)
+function Float:resize(width, height, position)
+  if position == nil then
+    position = self.position
+  end
+  local opts = create_opts(width, height, position)
   api.nvim_win_set_config(self.win_id, opts)
 end
 

--- a/lua/dapui/windows/init.lua
+++ b/lua/dapui/windows/init.lua
@@ -123,12 +123,6 @@ function M.open_float(name, element, position, settings)
     float_windows[name]:jump_to()
     return float_windows[name]
   end
-  if settings.position == "center" then
-    local screen_w = vim.opt.columns:get()
-    local screen_h = vim.opt.lines:get() - vim.opt.cmdheight:get()
-    position.line = (screen_h - settings.height) / 2
-    position.col = (screen_w - settings.width) / 2
-  end
   local buf = element.buffer()
   local float_win = require("dapui.windows.float").open_float({
     height = settings.height or 1,
@@ -156,10 +150,17 @@ function M.open_float(name, element, position, settings)
       end
     end
 
+    if settings.position == "center" then
+      local screen_w = vim.opt.columns:get()
+      local screen_h = vim.opt.lines:get() - vim.opt.cmdheight:get()
+      position.line = (screen_h - height) / 2
+      position.col = (screen_w - width) / 2
+    end
+
     if width <= 0 or height <= 0 then
       return
     end
-    float_win:resize(width, height)
+    float_win:resize(width, height, position)
   end
 
   nio.api.nvim_buf_attach(buf, true, {


### PR DESCRIPTION
When trying to open float element with `position="center"` but without `width` and `height` provided

```lua
require('dapui').float_element('breakpoints', {position='center'})
```

the float element is not opened and throws error which says that `settings.height` used in calculations is actually a `nil` value. 

<details><summary>Traceback</summary>
<p>

```
msg_show.lua_error Error executing vim.schedule lua callback: .../.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:100: Async task failed without callback: The coroutine failed with this message: 
...l/share/nvim/lazy/nvim-dap-ui/lua/dapui/windows/init.lua:129: attempt to perform arithmetic on field 'height' (a nil value)
stack traceback:
	...l/share/nvim/lazy/nvim-dap-ui/lua/dapui/windows/init.lua: in function 'open_float'
	...ey/.local/share/nvim/lazy/nvim-dap-ui/lua/dapui/init.lua:156: in function <.../.local/share/nvim/lazy/nvim-dap-ui/lua/dapui/init.lua:132>
stack traceback:
	[C]: in function 'error'
	.../.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:100: in function 'close_task'
	.../.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:122: in function 'cb'
	.../.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:188: in function <.../.local/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:187>
```

</p>
</details> 


**This PR fixes the error and allows float element to be opened in** `position="center"` **without having** `width` **and** `height` **(they will be calculated from element content size).**