### PR TITLE
fix(jump_to_frame): make sure that source.path exists before jumping to it

### DIFF
--- a/lua/dapui/client/lib.lua
+++ b/lua/dapui/client/lib.lua
@@ -30,8 +30,9 @@ return function(client)
         return util.open_buf(buf, line, column)
       end
 
-      if not source.path then
+      if not source.path or not vim.uv.fs_stat(source.path) then
         util.notify("No source available for frame", vim.log.levels.WARN)
+        return
       end
 
       local path = source.path


### PR DESCRIPTION
When you try to Open a Frame from DAPStacks window, if Adapter reported `source.path` for said Frame
but the path does not actually exist in the file system, `client_lib.jump_to_frame()` opens empty buffer for it and jumps to non-existing line (causing unhandled exception by `nio.api.nvim_win_set_cursor()` in `nvim-dap-ui/lua/dapui/util.lua:168`).

This PR fixes the problem by checking said case and early returning when it happens.

### before (throws exception and opens empty buffer):
![image](https://github.com/user-attachments/assets/96b3328a-8746-4f08-a4ce-c3284d9789a7)

![image](https://github.com/user-attachments/assets/b71cfcf1-f87f-49c0-805c-ce379fe7eeb6)


### after (prints warning and does nothing, as expected):
![image](https://github.com/user-attachments/assets/58021990-5a8d-4d8e-adf0-9eb8e797c056)
