### PR TITLE
Update README.md to use lazydev.nvim instead of neodev.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,12 @@ use { "rcarriga/nvim-dap-ui", requires = {"mfussenegger/nvim-dap", "nvim-neotest
 { "rcarriga/nvim-dap-ui", dependencies = {"mfussenegger/nvim-dap", "nvim-neotest/nvim-nio"} }
 ```
 
-It is highly recommended to use [neodev.nvim](https://github.com/folke/neodev.nvim) to enable type checking for nvim-dap-ui to get
+It is highly recommended to use [lazydev.nvim](https://github.com/folke/lazydev.nvim) to enable type checking for nvim-dap-ui to get
 type checking, documentation and autocompletion for all API functions.
 
 ```lua
-require("neodev").setup({
-  library = { plugins = { "nvim-dap-ui" }, types = true },
-  ...
+require("lazydev").setup({
+  library = { "nvim-dap-ui" },
 })
 ```
 


### PR DESCRIPTION
see this [issue](https://github.com/rcarriga/nvim-dap-ui/issues/367)