### PR TITLE
Add a description to mappings

### DIFF
--- a/lua/dapui/render/canvas.lua
+++ b/lua/dapui/render/canvas.lua
@@ -145,7 +145,7 @@ function Canvas:render_buffer(buffer, action_keys)
       for _, callback in pairs(callbacks) do
         callback()
       end
-    end, buffer)
+    end, buffer, action)
   end
 
   local lines = self.lines

--- a/lua/dapui/util.lua
+++ b/lua/dapui/util.lua
@@ -203,7 +203,7 @@ function M.get_selection(start, finish)
   return lines
 end
 
-function M.apply_mapping(mappings, func, buffer)
+function M.apply_mapping(mappings, func, buffer, label)
   for _, key in pairs(mappings) do
     if type(func) ~= "string" then
       vim.api.nvim_buf_set_keymap(
@@ -211,10 +211,10 @@ function M.apply_mapping(mappings, func, buffer)
         "n",
         key,
         "",
-        { noremap = true, callback = func, nowait = true }
+        { noremap = true, callback = func, nowait = true, desc = label, }
       )
     else
-      vim.api.nvim_buf_set_keymap(buffer, "n", key, func, { noremap = true, nowait = true })
+      vim.api.nvim_buf_set_keymap(buffer, "n", key, func, { noremap = true, nowait = true, desc = label, })
     end
   end
 end


### PR DESCRIPTION
Allow a user to use `map <buffer>` in a dapui buffer to see what the mappings do.

We already have descriptions for these mappings, so pass that through to the mapping definition. This also makes it easier for a user to know the names they need to use to change the keys bound to these mappings -- the strings are the keys used in mapping configuration.

Output of `:map <buffer>`:
![image](https://github.com/user-attachments/assets/a7781ce3-aba4-48eb-85a9-15e8e2499a83)
