### PR TITLE
lint: Fix style to match stylua

### DIFF
--- a/lua/dapui/util.lua
+++ b/lua/dapui/util.lua
@@ -211,10 +211,16 @@ function M.apply_mapping(mappings, func, buffer, label)
         "n",
         key,
         "",
-        { noremap = true, callback = func, nowait = true, desc = label, }
+        { noremap = true, callback = func, nowait = true, desc = label }
       )
     else
-      vim.api.nvim_buf_set_keymap(buffer, "n", key, func, { noremap = true, nowait = true, desc = label, })
+      vim.api.nvim_buf_set_keymap(
+        buffer,
+        "n",
+        key,
+        func,
+        { noremap = true, nowait = true, desc = label }
+      )
     end
   end
 end


### PR DESCRIPTION
stylua-action failed from my last pr. adjust style to match.

I ran this and it seems to be what it wants:
```vimscript
:exec "!" g:ale_lua_stylua_executable "-f ../../stylua.toml"  expand("%")
```
