### PR TITLE
Adapt highlights to current colorscheme

### DIFF
--- a/lua/dapui/config/highlights.lua
+++ b/lua/dapui/config/highlights.lua
@@ -14,39 +14,39 @@ local control_hl_groups = {
 
 function M.setup()
   vim.cmd([[
-  hi default link DapUINormal Normal
-  hi default link DapUIVariable Normal
-  hi default DapUIScope guifg=#00F1F5
-  hi default DapUIType guifg=#D484FF
-  hi default link DapUIValue Normal
-  hi default DapUIModifiedValue guifg=#00F1F5 gui=bold
-  hi default DapUIDecoration guifg=#00F1F5
-  hi default DapUIThread guifg=#A9FF68
-  hi default DapUIStoppedThread guifg=#00f1f5
-  hi default link DapUIFrameName Normal
-  hi default DapUISource guifg=#D484FF
-  hi default DapUILineNumber guifg=#00f1f5
-  hi default link DapUIFloatNormal NormalFloat
-  hi default DapUIFloatBorder guifg=#00F1F5
-  hi default DapUIWatchesEmpty guifg=#F70067
-  hi default DapUIWatchesValue guifg=#A9FF68
-  hi default DapUIWatchesError guifg=#F70067
-  hi default DapUIBreakpointsPath guifg=#00F1F5
-  hi default DapUIBreakpointsInfo guifg=#A9FF68
-  hi default DapUIBreakpointsCurrentLine guifg=#A9FF68 gui=bold
-  hi default link DapUIBreakpointsLine DapUILineNumber
-  hi default DapUIBreakpointsDisabledLine guifg=#424242
-  hi default link DapUICurrentFrameName DapUIBreakpointsCurrentLine
-  hi default DapUIStepOver guifg=#00f1f5
-  hi default DapUIStepInto guifg=#00f1f5
-  hi default DapUIStepBack guifg=#00f1f5
-  hi default DapUIStepOut guifg=#00f1f5
-  hi default DapUIStop guifg=#F70067
-  hi default DapUIPlayPause guifg=#A9FF68
-  hi default DapUIRestart guifg=#A9FF68
-  hi default DapUIUnavailable guifg=#424242
-  hi default DapUIWinSelect ctermfg=Cyan guifg=#00f1f5 gui=bold
-  hi default link DapUIEndofBuffer EndofBuffer
+  hi default link DapUINormal                  Normal
+  hi default link DapUIVariable                Normal
+  hi default link DapUIScope                   Identifier
+  hi default link DapUIType                    Type
+  hi default link DapUIValue                   Normal
+  hi default link DapUIModifiedValue           Function
+  hi default link DapUIDecoration              Identifier
+  hi default link DapUIThread                  Identifier
+  hi default link DapUIStoppedThread           Function
+  hi default link DapUIFrameName               Normal
+  hi default link DapUISource                  Define
+  hi default link DapUILineNumber              LineNr
+  hi default link DapUIFloatNormal             NormalFloat
+  hi default link DapUIFloatBorder             Identifier
+  hi default link DapUIWatchesEmpty            PreProc
+  hi default link DapUIWatchesValue            Statement
+  hi default link DapUIWatchesError            PreProc
+  hi default link DapUIBreakpointsPath         Identifier
+  hi default link DapUIBreakpointsInfo         Statement
+  hi default link DapUIBreakpointsCurrentLine  CursorLineNr
+  hi default link DapUIBreakpointsLine         DapUILineNumber
+  hi default link DapUIBreakpointsDisabledLine Comment
+  hi default link DapUICurrentFrameName        DapUIBreakpointsCurrentLine
+  hi default link DapUIStepOver                Label
+  hi default link DapUIStepInto                Label
+  hi default link DapUIStepBack                Label
+  hi default link DapUIStepOut                 Label
+  hi default link DapUIStop                    PreProc
+  hi default link DapUIPlayPause               Repeat
+  hi default link DapUIRestart                 Repeat
+  hi default link DapUIUnavailable             Comment
+  hi default link DapUIWinSelect               Special
+  hi default link DapUIEndofBuffer             EndofBuffer
   ]])
 
   ---gets the argument highlight group information, using the newer `nvim_get_hl` if available


### PR DESCRIPTION
Fixes #3, fixes #46.

Define dap colorscheme in terms of vim-defined group names so the colors will work with any colorscheme.

This changes the default colors and they'll be different for every colorscheme, but we'll never put light text on light backgrounds since we're using colors defined by the colorscheme.

ColorSchemes can define their own DapUIType and other highlights which will override ours (if they don't use default):

    hi DapUIModifiedValue guifg=#00F1F5 gui=bold

## Screenshots

You can see how much the old colours clash in some colorschemes, especially light ones. Dark ones like candycode looked good before and still look nice.

[sandydune](https://github.com/idbrii/vim-sandydune/) (my colorscheme) before and after:
![sandydune before](https://github.com/user-attachments/assets/872eda47-c607-44ad-b670-bcfb1f33c18f)
![sandydune after](https://github.com/user-attachments/assets/ab62f6f2-74d2-4e66-98ea-4a532e2a49be)

built-in `zellner` before and after:
![zellner before](https://github.com/user-attachments/assets/280b8be5-3ae2-4b06-976c-048709e56cd7)
![zellner after](https://github.com/user-attachments/assets/8a41e0f7-9cb2-4f43-ae1e-30833183be83)

[apprentice](https://github.com/romainl/Apprentice) before and after:
![apprentice before](https://github.com/user-attachments/assets/faf091f3-457f-482f-850d-9042810b3c42)
![apprentice after](https://github.com/user-attachments/assets/939816f6-1791-483f-8e42-4236e5ef89fb)

[candycode](https://github.com/vim-scripts/candycode.vim) before and after:
![candycode before](https://github.com/user-attachments/assets/138037ae-447c-4bd5-a1e4-95026dba760d)
![candycode after](https://github.com/user-attachments/assets/b00c68ae-88f3-4802-a682-823d941809cb)

built-in `blue` before and after:
![blue before](https://github.com/user-attachments/assets/0ed535e0-b56d-4160-98fe-b3547b7604ff)
![blue after](https://github.com/user-attachments/assets/651aa7bc-39a6-47e7-89b1-387aa8f60644)
