### PR TITLE
fix: nvim 0.11 overrides float border with default option if not set

### DIFF
--- a/lua/dapui/render/line_hover.lua
+++ b/lua/dapui/render/line_hover.lua
@@ -87,6 +87,7 @@ function M.show()
     width = content_width,
     height = 1,
     style = "minimal",
+    border = "none",
     row = 0,
     col = 0,
   }


### PR DESCRIPTION
Neovim v0.11 added `winborder` option that specifies border style of every float window that hasnt overriden it.
In order to preserve "no borders" look of `line_hover`, we have to set border style to `none`.

|before|after|
|-|-|
|![image](https://github.com/user-attachments/assets/ab4e1142-7024-4145-be67-09ab1fbfb43a)|![image](https://github.com/user-attachments/assets/2cfcc938-3b81-4449-9092-55fe7b84cfab)|