### PR TITLE
Add config option for text wrapping in UI windows

### DIFF
--- a/lua/dapui/config/init.lua
+++ b/lua/dapui/config/init.lua
@@ -4,6 +4,7 @@ local dapui = {}
 ---@toc_entry Configuration Options
 
 ---@class dapui.Config
+---@field wrap boolean Whether or not to wrap UI text
 ---@field icons dapui.Config.icons
 ---@field mappings table<dapui.Action, string|string[]> Keys to trigger actions in elements
 ---@field element_mappings table<string, table<dapui.Action, string|string[]>> Per-element overrides of global mappings
@@ -77,6 +78,7 @@ local dapui = {}
 ---@type dapui.Config
 ---@nodoc
 local default_config = {
+  wrap = false,
   icons = { expanded = "", collapsed = "", current_frame = "" },
   mappings = {
     -- Use a table to apply multiple mappings

--- a/lua/dapui/windows/layout.lua
+++ b/lua/dapui/windows/layout.lua
@@ -171,13 +171,14 @@ function WindowLayout:toggle()
 end
 
 function WindowLayout:_init_win_settings(win)
+  local config = require("dapui.config")
   local win_settings = {
     list = false,
     relativenumber = false,
     number = false,
     winfixwidth = true,
     winfixheight = true,
-    wrap = false,
+    wrap = config.wrap,
     signcolumn = "auto",
     spell = false,
   }


### PR DESCRIPTION
This PR adds a new config option `wrap` that lets the user choose to wrap the text within the UI windows. Defaults to `false`, the current default value.

Solves #435 