### PR TITLE
Refresh breakpoints window after breakpoint event

### DIFF
--- a/lua/dapui/components/breakpoints.lua
+++ b/lua/dapui/components/breakpoints.lua
@@ -11,6 +11,7 @@ return function(client, send_ready)
     "setFunctionBreakpoints",
     "setInstructionBreakpoints",
     "setDataBreakpoints",
+    "breakpoint",
     "stackTrace",
     "terminated",
     "exited",


### PR DESCRIPTION
nvim-dap added handling of breakpoint event ([ea82027](https://github.com/mfussenegger/nvim-dap/commit/ea82027)).
This is simple fix, so that breakpoints window is updated as well.