### PR TITLE
Fix first line in doc for local-additions

### DIFF
--- a/doc/nvim-dap-ui.txt
+++ b/doc/nvim-dap-ui.txt
@@ -1,4 +1,4 @@
-nvim-dap-ui.txt*	A UI for nvim-dap.
+*nvim-dap-ui.txt*	A UI for nvim-dap.
 
 ==============================================================================
 nvim-dap-ui                                                        *nvim-dap-ui*


### PR DESCRIPTION
The documentation for vim help pages states that the first line is required for the file to appear under `:help local-additions` muyst have the following format: `*tag* description`

The first asterisk was missing. This change fixes that