### PR TITLE
feat(ui): Add commands to manually update hover, scopes, and watches

### DIFF
--- a/lua/dapui/elements/hover.lua
+++ b/lua/dapui/elements/hover.lua
@@ -12,6 +12,10 @@ return function(client)
     dapui.elements.hover.render()
   end)
 
+  vim.api.nvim_create_user_command("DapuiUpdateHover", function()
+    send_ready()
+  end, {})
+
   local hover = require("dapui.components.hover")(client, send_ready)
 
   ---@nodoc

--- a/lua/dapui/elements/scopes.lua
+++ b/lua/dapui/elements/scopes.lua
@@ -20,6 +20,10 @@ return function(client)
     dapui.elements.scopes.render()
   end)
 
+  vim.api.nvim_create_user_command("DapuiUpdateScopes", function()
+    send_ready()
+  end, {})
+
   local scopes = require("dapui.components.scopes")(client, send_ready)
 
   ---@nodoc

--- a/lua/dapui/elements/watches.lua
+++ b/lua/dapui/elements/watches.lua
@@ -29,6 +29,10 @@ return function(client)
 
   local watches = require("dapui.components.watches")(client, send_ready)
 
+  vim.api.nvim_create_user_command("DapuiUpdateWatches", function()
+    send_ready()
+  end, {})
+
   --- Add a new watch expression
   ---@param expr? string
   function dapui.elements.watches.add(expr)


### PR DESCRIPTION
#### **Summary**

This pull request introduces three new user commands (`DapuiUpdateHover`, `DapuiUpdateScopes`, and `DapuiUpdateWatches`) to manually force an update of the corresponding UI components. This provides a necessary workaround for DAP adapters, like the one used with GDB, that don't trigger a re-render signal after certain changes are made via the REPL.

#### **Problem**

When using a DAP adapter, such as the one for GDB, certain debugger settings can be modified directly within the DAP REPL. A common example is changing the display format of values (e.g., setting `output-radix` to switch between decimal, hexadecimal, and octal representations).

However, these changes are often not propagated back to the editor, so `dap-ui`'s scopes and watches components do not automatically refresh. This leaves the UI displaying outdated information that doesn't reflect the current debugger configuration, forcing the user to manually toggle the component's visibility to see the updated values.

#### **Solution**

This PR adds dedicated user commands that explicitly trigger a re-render for the `hover`, `scopes`, and `watches` elements. These commands call the same internal `send_ready()` function that powers the standard UI updates, effectively forcing the components to fetch and display the latest data from the DAP server.

This approach provides a simple, direct, and explicit way for users to refresh their views whenever they make a change in the REPL that is not automatically reflected in the UI.

#### **Usage**

Users can now call these commands from the Neovim command line or map them to keys for quick access. For example, to refresh the scopes and watches view after changing the `output-radix` in the REPL:

```lua
-- After running a command like `set output-radix 16` in the REPL
:DapuiUpdateScopes
:DapuiUpdateWatches
```

These commands will force the UI to re-query the DAP server for the current scope variables and watch expressions, displaying them with the new formatting.

### Testing Instructions

To test this feature, you will need a DAP server and a debugger (like GDB) that supports changing the output radix via the REPL.

1.  Start a debugging session on a simple C/C++ program.
2.  Open the scopes and watches panes in `dap-ui`.
3.  In the DAP REPL, change the output format (e.g., `set output-radix 16`).
4.  Observe that the UI components do not update.
5.  Run `:DapuiUpdateScopes` and/or `:DapuiUpdateWatches`.
6.  The values in the scopes and watches panes should now be displayed in the new format (e.g., hexadecimal).