### PR TITLE
fix: source.path may lead to lsp client

### DIFF
--- a/lua/dapui/client/lib.lua
+++ b/lua/dapui/client/lib.lua
@@ -30,7 +30,7 @@ return function(client)
         return util.open_buf(buf, line, column)
       end
 
-      if not source.path or not vim.uv.fs_stat(source.path) then
+      if not source.path or (not util.is_uri(source.path) and not vim.uv.fs_stat(source.path)) then
         util.notify("No source available for frame", vim.log.levels.WARN)
         return
       end


### PR DESCRIPTION
For java projects, stack frames may points to jdt:// adresses which are resolved by lsp.

I think thant the No source available for frame condition check should be used only for local path resolution