### PR TITLE
feature: better evaluation of array variable

### DIFF
--- a/lua/dapui/components/hover.lua
+++ b/lua/dapui/components/hover.lua
@@ -92,7 +92,7 @@ return function(client, send_ready)
       end
 
       if expanded and var_ref then
-        render_vars.render(canvas, expression, var_ref, config.render.indent)
+        render_vars.render(canvas, expression, var_ref, config.render.indent, hover_expr)
       end
       canvas:remove_line()
     end,

--- a/lua/dapui/components/scopes.lua
+++ b/lua/dapui/components/scopes.lua
@@ -51,13 +51,13 @@ return function(client, send_ready)
         canvas:write({
           { scope_prefix(scope), group = "DapUIDecoration" },
           " ",
-          { scope.name, group = "DapUIScope" },
+          { scope.name,          group = "DapUIScope" },
           { ":\n" },
         })
 
         -- only render expanded scopes to save resources
         if not closed_scopes[scope.name] then
-          render_vars.render(canvas, scope.name, scope.variablesReference, config.render.indent)
+          render_vars.render(canvas, scope.name, scope.variablesReference, config.render.indent, scope)
         end
 
         if i < #scopes then

--- a/lua/dapui/components/variables.lua
+++ b/lua/dapui/components/variables.lua
@@ -36,17 +36,73 @@ return function(client, send_ready)
     return rendered_vars[path] and rendered_vars[path] ~= value
   end
 
+  ---@param parent_ref integer
+  ---@param parent? dapui.types.Variable|dapui.types.Scope|dapui.types.EvaluateResponse
+  ---@return dapui.types.Variable[]
+  local function fetch_variables(parent_ref, parent)
+    local variables = {}
+    local seen = {}
+
+    local function append(args)
+      local success, var_data = pcall(client.request.variables, args)
+      if not success or not var_data or not var_data.variables then
+        return
+      end
+
+      for _, variable in ipairs(var_data.variables) do
+        local key = table.concat({
+          variable.name or "",
+          variable.value or "",
+          tostring(variable.variablesReference or 0),
+        }, "\0")
+
+        if not seen[key] then
+          seen[key] = true
+          table.insert(variables, variable)
+        end
+      end
+    end
+
+    if parent then
+      local indexed = parent.indexedVariables or 0
+      local named = parent.namedVariables or 0
+
+      if indexed > 0 then
+        append({
+          variablesReference = parent_ref,
+          filter = "indexed",
+          start = 0,
+          count = indexed,
+        })
+      end
+
+      if named > 0 then
+        append({
+          variablesReference = parent_ref,
+          filter = "named",
+        })
+      end
+
+      if indexed > 0 or named > 0 then
+        return variables
+      end
+    end
+
+    append({ variablesReference = parent_ref })
+    return variables
+  end
+
   ---@param canvas dapui.Canvas
   ---@param parent_path string
   ---@param parent_ref integer
   ---@param indent integer
-  local function render(canvas, parent_path, parent_ref, indent)
+  ---@param parent? dapui.types.Variable|dapui.types.Scope|dapui.types.EvaluateResponse
+  local function render(canvas, parent_path, parent_ref, indent, parent)
     if not canvas.prompt and prompt_func then
       canvas:set_prompt("> ", prompt_func, { fill = prompt_fill })
     end
     indent = indent or 0
-    local success, var_data = pcall(client.request.variables, { variablesReference = parent_ref })
-    local variables = success and var_data.variables or {}
+    local variables = fetch_variables(parent_ref, parent)
     if config.render.sort_variables then
       table.sort(variables, config.render.sort_variables)
     end
@@ -57,7 +113,7 @@ return function(client, send_ready)
         string.rep(" ", indent),
         { reference_prefix(var_path, variable), group = "DapUIDecoration" },
         " ",
-        { variable.name, group = "DapUIVariable" },
+        { variable.name,                        group = "DapUIVariable" },
       })
 
       local var_type = util.render_type(variable.type)
@@ -111,7 +167,7 @@ return function(client, send_ready)
       end
 
       if expanded_children[var_path] and variable.variablesReference ~= 0 then
-        render(canvas, var_path, variable.variablesReference, indent + config.render.indent)
+        render(canvas, var_path, variable.variablesReference, indent + config.render.indent, variable)
       end
     end
   end

--- a/lua/dapui/components/watches.lua
+++ b/lua/dapui/components/watches.lua
@@ -80,8 +80,8 @@ return function(client, send_ready)
         return
       end
       local frame_id = client.session
-        and client.session.current_frame
-        and client.session.current_frame.id
+          and client.session.current_frame
+          and client.session.current_frame.id
       local step = client.lib.step_number()
       for i, watch in pairs(watches) do
         local success, evaluated
@@ -138,7 +138,7 @@ return function(client, send_ready)
 
         local var_ref = success and evaluated.variablesReference or 0
         if watch.expanded and var_ref > 0 then
-          render_vars.render(canvas, watch.expression, var_ref, config.render.indent)
+          render_vars.render(canvas, watch.expression, var_ref, config.render.indent, evaluated)
         end
         if rendered_step ~= step then
           rendered_exprs[i] = evaluated.result

--- a/lua/dapui/tests/mocks.lua
+++ b/lua/dapui/tests/mocks.lua
@@ -97,6 +97,7 @@ function M.client(args)
     seq = 0,
     stopped_thread_id = args.stopped_thread_id,
     current_frame = args.current_frame,
+    threads = {},
     set_breakpoints = function() end,
 
     request = function(_, command, request_args, callback)
@@ -105,6 +106,16 @@ function M.client(args)
         error("No request handler for " .. command)
       end
       local response = args.requests[command](request_args)
+      if command == "threads" then
+        session.threads = {}
+        for _, thread in ipairs(response.threads or {}) do
+          session.threads[thread.id] = vim.deepcopy(thread)
+        end
+      elseif command == "stackTrace" then
+        local thread_id = request_args.threadId
+        session.threads[thread_id] = session.threads[thread_id] or { id = thread_id }
+        session.threads[thread_id].frames = response.stackFrames
+      end
       for _, c in pairs(dap.listeners.before[command]) do
         c(session, nil, response, request_args)
       end

--- a/tests/unit/elements/hover_spec.lua
+++ b/tests/unit/elements/hover_spec.lua
@@ -2,6 +2,7 @@ local nio = require("nio")
 local a = nio.tests
 local Hover = require("dapui.elements.hover")
 local tests = require("dapui.tests")
+local util = require("dapui.util")
 tests.bootstrap()
 local mocks = tests.mocks
 
@@ -20,6 +21,7 @@ describe("hover element", function()
             a = "'a value'",
             ["b - 1"] = { result = "1", type = "number" },
             c = { result = "{ d = 1 }", type = "table", variablesReference = 1 },
+            arr = { result = "[1]", type = "Array", variablesReference = 2, indexedVariables = 1 },
           },
         }),
         variables = mocks.variables({
@@ -30,16 +32,26 @@ describe("hover element", function()
                 value = "1",
                 type = "number",
                 variablesReference = 0,
+              }
+            },
+            [2] = {
+              {
+                name = "0",
+                value = "1",
+                type = "number",
+                variablesReference = 0,
               },
             },
           },
         }),
-      },
+      }
     })
     hover = Hover(client)
     buf = hover.buffer()
   end)
   after_each(function()
+    client.shutdown()
+    util.stop_render_tasks()
     pcall(vim.api.nvim_buf_delete, buf, { force = true })
     hover = nil
   end)
@@ -69,9 +81,9 @@ describe("hover element", function()
     nio.sleep(10)
     local formatted = tests.util.get_highlights(buf)
     assert.same({
-      { "DapUIDecoration", 0, 0, 0, 4 },
-      { "DapUIType", 0, 6, 0, 11 },
-      { "DapUIValue", 0, 14, 0, 23 },
+      { "DapUIDecoration", 0, 0,  0, 4 },
+      { "DapUIType",       0, 6,  0, 11 },
+      { "DapUIValue",      0, 14, 0, 23 },
     }, formatted)
   end)
 
@@ -95,14 +107,25 @@ describe("hover element", function()
 
       local formatted = tests.util.get_highlights(buf)
       assert.same({
-        { "DapUIDecoration", 0, 0, 0, 4 },
-        { "DapUIType", 0, 6, 0, 11 },
-        { "DapUIValue", 0, 14, 0, 23 },
-        { "DapUIDecoration", 1, 1, 1, 2 },
-        { "DapUIVariable", 1, 3, 1, 4 },
-        { "DapUIType", 1, 5, 1, 11 },
-        { "DapUIValue", 1, 14, 1, 15 },
+        { "DapUIDecoration", 0, 0,  0, 4 },
+        { "DapUIType",       0, 6,  0, 11 },
+        { "DapUIValue",      0, 14, 0, 23 },
+        { "DapUIDecoration", 1, 1,  1, 2 },
+        { "DapUIVariable",   1, 3,  1, 4 },
+        { "DapUIType",       1, 5,  1, 11 },
+        { "DapUIValue",      1, 14, 1, 15 },
       }, formatted)
+    end)
+
+    a.it("renders indexed variables for expandable arrays", function()
+      hover.set_expression("arr")
+      nio.sleep(10)
+      local keymaps = tests.util.get_mappings(hover.buffer())
+      keymaps["<CR>"](1)
+      nio.sleep(10)
+
+      local lines = nio.api.nvim_buf_get_lines(buf, 0, -1, false)
+      assert.same({ " arr Array = [1]", "   0 number = 1" }, lines)
     end)
   end)
 end)

--- a/tests/unit/elements/scopes_spec.lua
+++ b/tests/unit/elements/scopes_spec.lua
@@ -2,6 +2,7 @@ local nio = require("nio")
 local a = nio.tests
 local Scopes = require("dapui.elements.scopes")
 local tests = require("dapui.tests")
+local util = require("dapui.util")
 tests.bootstrap()
 local mocks = tests.mocks
 
@@ -44,6 +45,13 @@ describe("scopes element", function()
                 type = "number",
                 variablesReference = 3,
               },
+              {
+                name = "arr",
+                value = "[1, 2]",
+                type = "Array",
+                variablesReference = 4,
+                indexedVariables = 2,
+              },
             },
             [2] = {
               {
@@ -61,6 +69,20 @@ describe("scopes element", function()
                 variablesReference = 0,
               },
             },
+            [4] = {
+              {
+                name = "0",
+                value = "1",
+                type = "number",
+                variablesReference = 0,
+              },
+              {
+                name = "1",
+                value = "2",
+                type = "number",
+                variablesReference = 0,
+              },
+            }
           },
         }),
       },
@@ -70,6 +92,8 @@ describe("scopes element", function()
     client.request.scopes({ frameId = 1 })
   end)
   after_each(function()
+    client.shutdown()
+    util.stop_render_tasks()
     pcall(vim.api.nvim_buf_delete, buf, { force = true })
     scopes = nil
   end)
@@ -79,6 +103,7 @@ describe("scopes element", function()
       " Locals:",
       "   a number = 1",
       "  b number = 2",
+      "  arr Array = [1, 2]",
       "",
       " Globals:",
       "   CONST_A boolean = true",
@@ -88,22 +113,26 @@ describe("scopes element", function()
   a.it("renders initial highlights", function()
     local formatted = tests.util.get_highlights(buf)
     assert.same({
-      { "DapUIDecoration", 0, 0, 0, 3 },
-      { "DapUIScope", 0, 4, 0, 10 },
-      { "DapUIDecoration", 1, 1, 1, 2 },
-      { "DapUIVariable", 1, 3, 1, 4 },
-      { "DapUIType", 1, 5, 1, 11 },
-      { "DapUIValue", 1, 14, 1, 15 },
-      { "DapUIDecoration", 2, 1, 2, 4 },
-      { "DapUIVariable", 2, 5, 2, 6 },
-      { "DapUIType", 2, 7, 2, 13 },
-      { "DapUIValue", 2, 16, 2, 17 },
-      { "DapUIDecoration", 4, 0, 4, 3 },
-      { "DapUIScope", 4, 4, 4, 11 },
-      { "DapUIDecoration", 5, 1, 5, 2 },
-      { "DapUIVariable", 5, 3, 5, 10 },
-      { "DapUIType", 5, 11, 5, 18 },
-      { "DapUIValue", 5, 21, 5, 25 },
+      { "DapUIDecoration", 0, 0,  0, 3 },
+      { "DapUIScope",      0, 4,  0, 10 },
+      { "DapUIDecoration", 1, 1,  1, 2 },
+      { "DapUIVariable",   1, 3,  1, 4 },
+      { "DapUIType",       1, 5,  1, 11 },
+      { "DapUIValue",      1, 14, 1, 15 },
+      { "DapUIDecoration", 2, 1,  2, 4 },
+      { "DapUIVariable",   2, 5,  2, 6 },
+      { "DapUIType",       2, 7,  2, 13 },
+      { "DapUIValue",      2, 16, 2, 17 },
+      { "DapUIDecoration", 3, 1,  3, 4 },
+      { "DapUIVariable",   3, 5,  3, 8 },
+      { "DapUIType",       3, 9,  3, 14 },
+      { "DapUIValue",      3, 17, 3, 23 },
+      { "DapUIDecoration", 5, 0,  5, 3 },
+      { "DapUIScope",      5, 4,  5, 11 },
+      { "DapUIDecoration", 6, 1,  6, 2 },
+      { "DapUIVariable",   6, 3,  6, 10 },
+      { "DapUIType",       6, 11, 6, 18 },
+      { "DapUIValue",      6, 21, 6, 25 },
     }, formatted)
   end)
 
@@ -118,6 +147,7 @@ describe("scopes element", function()
         "   a number = 1",
         "  b number = 2",
         "    c string = '3'",
+        "  arr Array = [1, 2]",
         "",
         " Globals:",
         "   CONST_A boolean = true",
@@ -129,27 +159,49 @@ describe("scopes element", function()
       nio.sleep(10)
       local formatted = tests.util.get_highlights(buf)
       assert.same({
-        { "DapUIDecoration", 0, 0, 0, 3 },
-        { "DapUIScope", 0, 4, 0, 10 },
-        { "DapUIDecoration", 1, 1, 1, 2 },
-        { "DapUIVariable", 1, 3, 1, 4 },
-        { "DapUIType", 1, 5, 1, 11 },
-        { "DapUIValue", 1, 14, 1, 15 },
-        { "DapUIDecoration", 2, 1, 2, 4 },
-        { "DapUIVariable", 2, 5, 2, 6 },
-        { "DapUIType", 2, 7, 2, 13 },
-        { "DapUIValue", 2, 16, 2, 17 },
-        { "DapUIDecoration", 3, 2, 3, 3 },
-        { "DapUIVariable", 3, 4, 3, 5 },
-        { "DapUIType", 3, 6, 3, 12 },
-        { "DapUIValue", 3, 15, 3, 18 },
-        { "DapUIDecoration", 5, 0, 5, 3 },
-        { "DapUIScope", 5, 4, 5, 11 },
-        { "DapUIDecoration", 6, 1, 6, 2 },
-        { "DapUIVariable", 6, 3, 6, 10 },
-        { "DapUIType", 6, 11, 6, 18 },
-        { "DapUIValue", 6, 21, 6, 25 },
+        { "DapUIDecoration", 0, 0,  0, 3 },
+        { "DapUIScope",      0, 4,  0, 10 },
+        { "DapUIDecoration", 1, 1,  1, 2 },
+        { "DapUIVariable",   1, 3,  1, 4 },
+        { "DapUIType",       1, 5,  1, 11 },
+        { "DapUIValue",      1, 14, 1, 15 },
+        { "DapUIDecoration", 2, 1,  2, 4 },
+        { "DapUIVariable",   2, 5,  2, 6 },
+        { "DapUIType",       2, 7,  2, 13 },
+        { "DapUIValue",      2, 16, 2, 17 },
+        { "DapUIDecoration", 3, 2,  3, 3 },
+        { "DapUIVariable",   3, 4,  3, 5 },
+        { "DapUIType",       3, 6,  3, 12 },
+        { "DapUIValue",      3, 15, 3, 18 },
+        { "DapUIDecoration", 4, 1,  4, 4 },
+        { "DapUIVariable",   4, 5,  4, 8 },
+        { "DapUIType",       4, 9,  4, 14 },
+        { "DapUIValue",      4, 17, 4, 23 },
+        { "DapUIDecoration", 6, 0,  6, 3 },
+        { "DapUIScope",      6, 4,  6, 11 },
+        { "DapUIDecoration", 7, 1,  7, 2 },
+        { "DapUIVariable",   7, 3,  7, 10 },
+        { "DapUIType",       7, 11, 7, 18 },
+        { "DapUIValue",      7, 21, 7, 25 },
       }, formatted)
+    end)
+
+    a.it("renders indexed variables for expanded arrays", function()
+      local keymaps = tests.util.get_mappings(scopes.buffer())
+      keymaps["<CR>"](4)
+      nio.sleep(10)
+      local lines = nio.api.nvim_buf_get_lines(buf, 0, -1, false)
+      assert.same({
+        " Locals:",
+        "   a number = 1",
+        "  b number = 2",
+        "  arr Array = [1, 2]",
+        "    0 number = 1",
+        "    1 number = 2",
+        "",
+        " Globals:",
+        "   CONST_A boolean = true",
+      }, lines)
     end)
   end)
 end)

--- a/tests/unit/elements/stacks_spec.lua
+++ b/tests/unit/elements/stacks_spec.lua
@@ -2,6 +2,7 @@ local nio = require("nio")
 local a = nio.tests
 local Stacks = require("dapui.elements.stacks")
 local tests = require("dapui.tests")
+local util = require("dapui.util")
 tests.bootstrap()
 local mocks = tests.mocks
 
@@ -92,6 +93,7 @@ describe("stacks element", function()
     pcall(vim.api.nvim_buf_delete, buf, { force = true })
     stacks = nil
     client.shutdown()
+    util.stop_render_tasks()
   end)
   a.it("renders initial lines", function()
     stacks.render()
@@ -112,17 +114,17 @@ describe("stacks element", function()
     stacks.render()
     local formatted = tests.util.get_highlights(buf)
     assert.same({
-      { "DapUIThread", 0, 0, 0, 8 },
-      { "DapUICurrentFrameName", 1, 4, 1, 17 },
-      { "DapUISource", 1, 18, 1, 24 },
-      { "DapUILineNumber", 1, 25, 1, 26 },
-      { "DapUIThread", 3, 0, 3, 8 },
-      { "DapUIFrameName", 4, 1, 4, 14 },
-      { "DapUISource", 4, 15, 4, 21 },
-      { "DapUILineNumber", 4, 22, 4, 23 },
-      { "DapUIFrameName", 5, 1, 5, 14 },
-      { "DapUISource", 5, 15, 5, 21 },
-      { "DapUILineNumber", 5, 22, 5, 23 },
+      { "DapUIThread",           0, 0,  0, 8 },
+      { "DapUICurrentFrameName", 1, 4,  1, 17 },
+      { "DapUISource",           1, 18, 1, 24 },
+      { "DapUILineNumber",       1, 25, 1, 26 },
+      { "DapUIThread",           3, 0,  3, 8 },
+      { "DapUIFrameName",        4, 1,  4, 14 },
+      { "DapUISource",           4, 15, 4, 21 },
+      { "DapUILineNumber",       4, 22, 4, 23 },
+      { "DapUIFrameName",        5, 1,  5, 14 },
+      { "DapUISource",           5, 15, 5, 21 },
+      { "DapUILineNumber",       5, 22, 5, 23 },
     }, formatted)
   end)
 
@@ -152,20 +154,20 @@ describe("stacks element", function()
       stacks.render()
       local formatted = tests.util.get_highlights(buf)
       assert.same({
-        { "DapUIThread", 0, 0, 0, 8 },
-        { "DapUICurrentFrameName", 1, 4, 1, 17 },
-        { "DapUISource", 1, 18, 1, 24 },
-        { "DapUILineNumber", 1, 25, 1, 26 },
-        { "DapUIFrameName", 2, 1, 2, 14 },
-        { "DapUISource", 2, 15, 2, 21 },
-        { "DapUILineNumber", 2, 22, 2, 23 },
-        { "DapUIThread", 4, 0, 4, 8 },
-        { "DapUIFrameName", 5, 1, 5, 14 },
-        { "DapUISource", 5, 15, 5, 21 },
-        { "DapUILineNumber", 5, 22, 5, 23 },
-        { "DapUIFrameName", 6, 1, 6, 14 },
-        { "DapUISource", 6, 15, 6, 21 },
-        { "DapUILineNumber", 6, 22, 6, 23 },
+        { "DapUIThread",           0, 0,  0, 8 },
+        { "DapUICurrentFrameName", 1, 4,  1, 17 },
+        { "DapUISource",           1, 18, 1, 24 },
+        { "DapUILineNumber",       1, 25, 1, 26 },
+        { "DapUIFrameName",        2, 1,  2, 14 },
+        { "DapUISource",           2, 15, 2, 21 },
+        { "DapUILineNumber",       2, 22, 2, 23 },
+        { "DapUIThread",           4, 0,  4, 8 },
+        { "DapUIFrameName",        5, 1,  5, 14 },
+        { "DapUISource",           5, 15, 5, 21 },
+        { "DapUILineNumber",       5, 22, 5, 23 },
+        { "DapUIFrameName",        6, 1,  6, 14 },
+        { "DapUISource",           6, 15, 6, 21 },
+        { "DapUILineNumber",       6, 22, 6, 23 },
       }, formatted)
     end)
   end)

--- a/tests/unit/elements/watches_spec.lua
+++ b/tests/unit/elements/watches_spec.lua
@@ -2,6 +2,7 @@ local nio = require("nio")
 local a = nio.tests
 local Watches = require("dapui.elements.watches")
 local tests = require("dapui.tests")
+local util = require("dapui.util")
 tests.bootstrap()
 local mocks = tests.mocks
 
@@ -45,13 +46,15 @@ describe("watches element", function()
     watches.render()
   end)
   after_each(function()
+    client.shutdown()
+    util.stop_render_tasks()
     pcall(vim.api.nvim_buf_delete, buf, { force = true })
     watches = nil
   end)
   describe("with no expressions", function()
     a.it("renders no expressions lines", function()
       local lines = nio.api.nvim_buf_get_lines(buf, 0, -1, false)
-      assert.same({ "No Expressions", "" }, lines)
+      assert.same({ "No Expressions", "> " }, lines)
     end)
     a.it("renders lines after expression update", function()
       local highlights = tests.util.get_highlights(buf)
@@ -66,7 +69,7 @@ describe("watches element", function()
     nio.sleep(10)
     local lines = nio.api.nvim_buf_get_lines(buf, 0, -1, false)
     assert.same(
-      { " a = 'a value'", " b - 1 number = 1", " c table = { d = 1 }", "" },
+      { " a = 'a value'", " b - 1 number = 1", " c table = { d = 1 }", "> " },
       lines
     )
   end)
@@ -78,13 +81,13 @@ describe("watches element", function()
     nio.sleep(10)
     local highlights = tests.util.get_highlights(buf)
     assert.same({
-      { "DapUIWatchesValue", 0, 0, 0, 3 },
-      { "DapUIModifiedValue", 0, 8, 0, 17 },
-      { "DapUIWatchesValue", 1, 0, 1, 3 },
-      { "DapUIType", 1, 10, 1, 16 },
+      { "DapUIWatchesValue",  0, 0,  0, 3 },
+      { "DapUIModifiedValue", 0, 8,  0, 17 },
+      { "DapUIWatchesValue",  1, 0,  1, 3 },
+      { "DapUIType",          1, 10, 1, 16 },
       { "DapUIModifiedValue", 1, 19, 1, 20 },
-      { "DapUIWatchesValue", 2, 0, 2, 3 },
-      { "DapUIType", 2, 6, 2, 11 },
+      { "DapUIWatchesValue",  2, 0,  2, 3 },
+      { "DapUIType",          2, 6,  2, 11 },
       { "DapUIModifiedValue", 2, 14, 2, 23 },
     }, highlights)
   end)
@@ -96,7 +99,7 @@ describe("watches element", function()
       nio.sleep(10)
 
       local lines = nio.api.nvim_buf_get_lines(buf, 0, -1, false)
-      assert.same({ " c table = { d = 1 }", "   d number = 1", "" }, lines)
+      assert.same({ " c table = { d = 1 }", "   d number = 1", "> " }, lines)
     end)
     a.it("renders expanded highlights", function()
       watches.add("c")
@@ -105,13 +108,13 @@ describe("watches element", function()
 
       local highlights = tests.util.get_highlights(buf)
       assert.same({
-        { "DapUIWatchesValue", 0, 0, 0, 3 },
-        { "DapUIType", 0, 6, 0, 11 },
+        { "DapUIWatchesValue",  0, 0,  0, 3 },
+        { "DapUIType",          0, 6,  0, 11 },
         { "DapUIModifiedValue", 0, 14, 0, 23 },
-        { "DapUIDecoration", 1, 1, 1, 2 },
-        { "DapUIVariable", 1, 3, 1, 4 },
-        { "DapUIType", 1, 5, 1, 11 },
-        { "DapUIValue", 1, 14, 1, 15 },
+        { "DapUIDecoration",    1, 1,  1, 2 },
+        { "DapUIVariable",      1, 3,  1, 4 },
+        { "DapUIType",          1, 5,  1, 11 },
+        { "DapUIValue",         1, 14, 1, 15 },
       }, highlights)
     end)
   end)


### PR DESCRIPTION
## Summary

This pull request updates variable fetching so `nvim-dap-ui` can correctly render values that expose their children through DAP's `indexedVariables` and `namedVariables` fields.

Today, variable rendering relies on a single unfiltered `variables` request. That works for many adapters, but it can miss indexed children for array-like values. In practice, this shows up with expandable arrays returning metadata such as class information while skipping the actual elements. This change adds explicit support for fetching indexed and named children separately, merging them for display, and preserving the existing fallback behavior when that metadata is not available.

## Changes

- Add `fetch_variables(parent_ref, parent)` in `lua/dapui/components/variables.lua`.
- Fetch indexed children with `filter = "indexed"` when `indexedVariables > 0`.
- Fetch named children with `filter = "named"` when `namedVariables > 0`.
- Merge both responses and deduplicate overlapping entries before rendering.
- Fall back to the existing unfiltered `variables` request when indexed/named counts are not provided.
- Pass the parent scope/variable/evaluate response into variable rendering from scopes, hover, and watches so child fetches can use the parent metadata.
- Update test mocks to persist `session.threads` and cached `stackTrace` frames, matching the session state shape used by `nvim-dap`.
- Extend unit coverage for indexed array rendering in hover and scopes.
- Refresh watch and stack tests to align with current rendering behavior and clean up async render tasks between tests.

## Exemple

In Ruby

 Now
```
    <U+EB6E> my_array Array = [#<Dog:0x00007f4d3e2be778 @name="Fido">, #<Dog:0x00007f4d3e2be6d8 @name="Rex">]
     <U+EB6E> 0 Dog = #<Dog:0x00007f4d3e2be778 @name="Fido">
      <U+EB70> #class Class = Dog
      <U+EB70> @name String = "Fido"
     <U+EB6E> 1 Dog = #<Dog:0x00007f4d3e2be6d8 @name="Rex">
      <U+EB70> #class Class = Dog
      <U+EB70> @name String = "Rex"
```

Before
```
    <U+EB6E> my_array Array = [#<Dog:0x00007f4016bb0d20 @name="Fido">, #<Dog:0x00007f4016bb0c80 @name="Rex">]
     <U+EB70> #class Class = Array
```
