### PR TITLE
feat: add stacks_request_limit config option

### DIFF
--- a/doc/nvim-dap-ui.txt
+++ b/doc/nvim-dap-ui.txt
@@ -119,7 +119,8 @@ Default values:
     render = {
       indent = 1,
       max_value_lines = 100
-    }
+    },
+    stacks_request_limit = -1,
   }
 <
 Parameters~
@@ -271,6 +272,8 @@ Layouts are opened in the order defined
 after initial setup
 {select_window?} `(fun(): integer)` A function which returns a window to be
 used for opening buffers such as a stack frame location.
+{stacks_request_limit} `(integer)` Tells how many threads the debugee can
+have when automatically requesting Stacks for it. -1 disables the limit.
 
                                                             *dapui.Config.icons*
 Fields~

--- a/lua/dapui/components/frames.lua
+++ b/lua/dapui/components/frames.lua
@@ -25,7 +25,7 @@ return function(client, send_ready)
       end
 
       local frames = threads[thread_id].frames
-      if not frames then
+      if not frames and (config.stacks_request_limit < 0 or vim.tbl_count(threads) <= config.stacks_request_limit) then
         local success, response = pcall(client.request.stackTrace, { threadId = thread_id })
         frames = success and response.stackFrames
       end

--- a/lua/dapui/config/init.lua
+++ b/lua/dapui/config/init.lua
@@ -20,6 +20,8 @@ local dapui = {}
 --- after initial setup
 ---@field select_window? fun(): integer A function which returns a window to be
 --- used for opening buffers such as a stack frame location.
+---@field stacks_request_limit integer Tells how many threads the debugee can
+--- have when automatically requesting Stacks for it. -1 disables the limit.
 
 ---@class dapui.Config.icons
 ---@field expanded string
@@ -146,6 +148,7 @@ local default_config = {
     max_value_lines = 100, -- Can be integer or nil.
     indent = 1,
   },
+  stacks_request_limit = -1,
 }
 
 local user_config = default_config


### PR DESCRIPTION
Refs: https://github.com/rcarriga/nvim-dap-ui/issues/418
Refs: https://github.com/rcarriga/nvim-dap-ui/issues/429
Refs: https://github.com/rcarriga/nvim-dap-ui/issues/442
Refs: https://github.com/rcarriga/nvim-dap-ui/pull/395

This is NOT a proper fix for any of linked Issues, but rather a simple workaround.

As I said in https://github.com/rcarriga/nvim-dap-ui/issues/429#issuecomment-4127676483, there are more problems that reverting https://github.com/rcarriga/nvim-dap-ui/commit/055be38c3653923d1d3e0f155a50871545740798 won't magically solve, however, doing `stacks_request_limit = 0` should result in similar behavior for people who need it.

I'm not entirely happy about "stacks_request_limit" name, and about how that branch looks like now, but I just wanted to have something to show. Suggestions welcome :)

IMO, this should also have a sane default, like `5` or `10`, but that would be a breaking change, and I don't want to be the one making it.