### PR TITLE
fix: reusing buffers crashing (nvim 0.11+)

### DIFF
--- a/lua/dapui/elements/console.lua
+++ b/lua/dapui/elements/console.lua
@@ -48,7 +48,16 @@ return function()
     return console_buf
   end
 
-  dap.defaults.fallback.terminal_win_cmd = get_buf
+  -- Neovim 0.11 deprecated termopen() in favor of jobstart(..., {term = true})
+  -- This requires the target buffer to be empty, unmodified and not a terminal buffer
+  local function acquire_terminal_buf()
+    if nio.api.nvim_buf_is_valid(console_buf) and vim.bo[console_buf].buftype == "terminal" then
+      console_buf = -1
+    end
+    return get_buf()
+  end
+
+  dap.defaults.fallback.terminal_win_cmd = acquire_terminal_buf
 
   function dapui.elements.console.render() end
 


### PR DESCRIPTION
## Description

First of all thank you for a great plugin! Truly amazing work🧑‍🍳

From time to time I have been slapped with this stack trace but never been able to reproduce it reliably. After working on aspire support in my own plugin I managed to reproduce and debug.

It looks like an nvim-dap bug but nvim-dap is correctly calling `jobstart{term = true}` https://github.com/mfussenegger/nvim-dap/blob/master/lua/dap/session.lua#L271

`dapui/elements/console.lua` caches one module-level console_buf and registers `dap.defaults.fallback.terminal_win_cmd = get_buf`. Every runInTerminal reuses that single buffer. causing it to sometimes reuse a buffer that is already hosting a terminal.

```
nvim-dap/lua/dap/session.lua:269: Lua: Vim:jobstart(...,{term=true}) requires unmodified buffer
stack traceback:
    [C]: in function 'termopen'
    ...dmin/.local/share/nvim/lazy/nvim-dap/lua/dap/session.lua:272: in function <...dmin/.local/share/nvim/lazy/nvim-dap/lua/dap/session.lua:269>
    [C]: in function 'nvim_buf_call'
    ...dmin/.local/share/nvim/lazy/nvim-dap/lua/dap/session.lua:269: in function 'handler'
    ...dmin/.local/share/nvim/lazy/nvim-dap/lua/dap/session.lua:1129: in function 'handle_body'
    ...dmin/.local/share/nvim/lazy/nvim-dap/lua/dap/session.lua:1516: in function ''
    vim/_core/editor.lua: in function <vim/_core/editor.lua:0>
stack traceback:
    [C]: in function 'nvim_buf_call'
    ...dmin/.local/share/nvim/lazy/nvim-dap/lua/dap/session.lua:269: in function 'handler'
    ...dmin/.local/share/nvim/lazy/nvim-dap/lua/dap/session.lua:1129: in function 'handle_body'
    ...dmin/.local/share/nvim/lazy/nvim-dap/lua/dap/session.lua:1516: in function ''
    vim/_core/editor.lua: in function <vim/_core/editor.lua:0>
```


## Minimal repro

1. nvim 0.11+/0.12, nvim-dap + nvim-dap-ui with a console element in the layout, a config with console = "integratedTerminal".
2. Debug any program → works. Stop. Debug again → throws. (Or start two integratedTerminal sessions concurrently → the 2nd throws.)
