### PR TITLE
Fix old expression fill in canvas.lua

### DIFF
--- a/lua/dapui/render/canvas.lua
+++ b/lua/dapui/render/canvas.lua
@@ -188,9 +188,11 @@ function Canvas:render_buffer(buffer, action_keys)
       self.prompt.callback(value)
     end)
     if self.prompt.fill then
-      api.nvim_buf_set_lines(buffer, -1, -1, true, { "> " .. self.prompt.fill })
+      api.nvim_buf_set_lines(buffer, -1, -1, true, { self.prompt.fill })
       if api.nvim_get_current_buf() == buffer then
-        api.nvim_input("A")
+        api.nvim_input("I")
+        api.nvim_input("<C-d>")
+        api.nvim_input("<End>")
       end
     end
     api.nvim_buf_set_option(buffer, "modified", false)


### PR DESCRIPTION
old expression in new line. need to fill after prompt. not need "<" one more time